### PR TITLE
feat: move source_clusters and brokers_per_cluster to link.conf

### DIFF
--- a/cluster-link/README.md
+++ b/cluster-link/README.md
@@ -24,6 +24,21 @@ link_name        = my-cluster-link
 source_bootstrap = broker1.example.com:9093,broker2.example.com:9093
 ```
 
+For ServiceNow active-active mode (dual-cluster), use `source_host` instead of `source_bootstrap`. The tool creates one link per cluster in `source_clusters` and polls each to `ACTIVE`:
+
+```ini
+[confluent]
+environment_id      = env-xxxxxx
+cluster_id          = lkc-xxxxxx
+link_name           = servicenow-link
+source_host         = hermes1.service-now.com
+instance_name       = snc.yourinstance
+
+# Optional — defaults shown:
+# source_clusters     = 4100, 4200
+# brokers_per_cluster = 4
+```
+
 `link.conf` is gitignored — your live IDs stay local.
 
 ## Usage

--- a/cluster-link/create_link.py
+++ b/cluster-link/create_link.py
@@ -21,14 +21,15 @@ import time
 
 REQUIRED_KEYS = ("environment_id", "cluster_id", "link_name")
 
-# ServiceNow active-active: base port for each source cluster, 4 brokers each
+# ServiceNow active-active: base port for each source cluster, 4 brokers each.
+# These are the defaults; both can be overridden in link.conf.
 SN_SOURCE_CLUSTERS = [4100, 4200]
 SN_BROKERS_PER_CLUSTER = 4
 
 
-def sn_bootstrap(host: str, base_port: int) -> str:
+def sn_bootstrap(host: str, base_port: int, brokers_per_cluster: int = SN_BROKERS_PER_CLUSTER) -> str:
     """Build a bootstrap string for one ServiceNow source cluster."""
-    return ",".join(f"{host}:{base_port + i}" for i in range(SN_BROKERS_PER_CLUSTER))
+    return ",".join(f"{host}:{base_port + i}" for i in range(brokers_per_cluster))
 
 CONFLUENT_INSTALL = """\
 Confluent CLI not found. Install it:
@@ -63,7 +64,16 @@ def load_config(path: str) -> dict:
             file=sys.stderr,
         )
         sys.exit(1)
-    return dict(section)
+    result = dict(section)
+    clusters_raw = result.get("source_clusters", "")
+    result["source_clusters"] = (
+        [int(x.strip()) for x in clusters_raw.split(",") if x.strip()]
+        if clusters_raw
+        else list(SN_SOURCE_CLUSTERS)
+    )
+    bpc_raw = result.get("brokers_per_cluster", "")
+    result["brokers_per_cluster"] = int(bpc_raw) if bpc_raw else SN_BROKERS_PER_CLUSTER
+    return result
 
 
 def check_confluent_cli() -> None:
@@ -311,14 +321,18 @@ def main() -> None:
     # Downstream consumers subscribe to both and handle deduplication.
     if "source_host" in cfg:
         links = [
-            {**cfg, "link_name": f"{cfg['link_name']}-4100", "source_bootstrap": sn_bootstrap(cfg["source_host"], 4100)},
-            {**cfg, "link_name": f"{cfg['link_name']}-4200", "source_bootstrap": sn_bootstrap(cfg["source_host"], 4200)},
+            {
+                **cfg,
+                "link_name": f"{cfg['link_name']}-{port}",
+                "source_bootstrap": sn_bootstrap(cfg["source_host"], port, cfg["brokers_per_cluster"]),
+            }
+            for port in cfg["source_clusters"]
         ]
     else:
         links = [cfg]
 
     for link_cfg in links:
-        port = 4100 if link_cfg["link_name"].endswith("-4100") else 4200
+        port = int(link_cfg["link_name"].rsplit("-", 1)[1])
         props = build_ssl_properties(
             ca_pem, client_cert, client_key,
             literal_newlines=args.literal_newlines,

--- a/cluster-link/link.conf.example
+++ b/cluster-link/link.conf.example
@@ -22,8 +22,12 @@ source_bootstrap = broker1.example.com:9093,broker2.example.com:9093
 # when creating mirror topics via the mirror management script.
 #
 # [confluent]
-# environment_id = env-xxxxxx
-# cluster_id     = lkc-xxxxxx
-# link_name      = servicenow-link
-# source_host    = hermes1.service-now.com
-# instance_name  = snc.yourinstance   # topic prefix filter for mirror-topics tool
+# environment_id      = env-xxxxxx
+# cluster_id          = lkc-xxxxxx
+# link_name           = servicenow-link
+# source_host         = kafka.example.com
+# instance_name       = snc.yourinstance   # topic prefix filter for mirror-topics tool
+#
+# Optional overrides (defaults shown):
+# source_clusters     = 4100, 4200   # comma-separated base ports, one link per cluster
+# brokers_per_cluster = 4            # brokers per cluster (ports base, base+1, ...)

--- a/cluster-link/tests/test_create_link.py
+++ b/cluster-link/tests/test_create_link.py
@@ -37,6 +37,12 @@ def test_sn_bootstrap_4200():
     assert result == "kafka.example.com:4200,kafka.example.com:4201,kafka.example.com:4202,kafka.example.com:4203"
 
 
+def test_sn_bootstrap_custom_brokers_per_cluster():
+    from create_link import sn_bootstrap
+    result = sn_bootstrap("kafka.example.com", 5000, brokers_per_cluster=2)
+    assert result == "kafka.example.com:5000,kafka.example.com:5001"
+
+
 # ---------------------------------------------------------------------------
 # load_config
 # ---------------------------------------------------------------------------
@@ -83,6 +89,44 @@ def test_load_config_accepts_source_host(tmp_path):
     path = write_config(tmp_path, cfg_text)
     cfg = load_config(path)
     assert cfg["source_host"] == "kafka.example.com"
+
+
+def test_load_config_defaults_source_clusters_and_brokers(tmp_path):
+    from create_link import load_config, SN_SOURCE_CLUSTERS, SN_BROKERS_PER_CLUSTER
+    path = write_config(tmp_path)
+    cfg = load_config(path)
+    assert cfg["source_clusters"] == SN_SOURCE_CLUSTERS
+    assert cfg["brokers_per_cluster"] == SN_BROKERS_PER_CLUSTER
+
+
+def test_load_config_reads_custom_source_clusters(tmp_path):
+    from create_link import load_config
+    cfg_text = textwrap.dedent("""\
+        [confluent]
+        environment_id   = env-abc123
+        cluster_id       = lkc-abc123
+        link_name        = test-link
+        source_bootstrap = broker.example.com:9093
+        source_clusters  = 5000, 5100
+    """)
+    path = write_config(tmp_path, cfg_text)
+    cfg = load_config(path)
+    assert cfg["source_clusters"] == [5000, 5100]
+
+
+def test_load_config_reads_custom_brokers_per_cluster(tmp_path):
+    from create_link import load_config
+    cfg_text = textwrap.dedent("""\
+        [confluent]
+        environment_id      = env-abc123
+        cluster_id          = lkc-abc123
+        link_name           = test-link
+        source_bootstrap    = broker.example.com:9093
+        brokers_per_cluster = 2
+    """)
+    path = write_config(tmp_path, cfg_text)
+    cfg = load_config(path)
+    assert cfg["brokers_per_cluster"] == 2
 
 
 def test_load_config_exits_if_neither_source_key(tmp_path):

--- a/mirror-topics/README.md
+++ b/mirror-topics/README.md
@@ -1,6 +1,6 @@
 # mirror-topics
 
-Mirrors ServiceNow Kafka topics to Confluent Cloud across both DC cluster links (`-4100` and `-4200`). Presents a checkbox UI to select topics, skips already-mirrored ones, and optionally enables auto-mirror for all future topics.
+Mirrors ServiceNow Kafka topics to Confluent Cloud across all source cluster links. Presents a checkbox UI to select topics, skips already-mirrored ones, and optionally enables auto-mirror for all future topics.
 
 ## Prerequisites
 
@@ -42,9 +42,13 @@ python mirror_topics.py --pem-dir /tmp/pems
 [confluent]
 environment_id = env-xxxxxx
 cluster_id     = lkc-xxxxxx
-link_name      = my-cluster-link     # tool appends -4100 and -4200
-source_host    = broker.example.com  # brokers at ports 4100–4103 and 4200–4203
-instance_name  = myinstance          # default topic filter prefix
+link_name      = my-cluster-link       # tool appends -<port> per source cluster
+source_host    = kafka.example.com     # brokers addressed as <host>:<port+n>
+instance_name  = myinstance            # default topic filter prefix
+
+# Optional — defaults shown:
+# source_clusters     = 4100, 4200     # one link created per cluster
+# brokers_per_cluster = 4
 ```
 
 `link.conf` is gitignored — your live IDs stay local.

--- a/mirror-topics/mirror_topics.py
+++ b/mirror-topics/mirror_topics.py
@@ -14,6 +14,8 @@ import sys
 from kafka import KafkaConsumer
 
 INTERNAL_TOPIC_PREFIXES = ("__", "_confluent")
+# Defaults; both can be overridden in link.conf.
+SN_SOURCE_CLUSTERS = [4100, 4200]
 SN_BROKERS_PER_CLUSTER = 4
 
 CONFLUENT_INSTALL = """\
@@ -42,8 +44,17 @@ def load_config(path: str) -> dict:
             print(f"Error: Missing key in link.conf: {key}", file=sys.stderr)
             sys.exit(1)
     result = dict(section)
-    result["link_name_4100"] = f"{result['link_name']}-4100"
-    result["link_name_4200"] = f"{result['link_name']}-4200"
+    clusters_raw = result.get("source_clusters", "")
+    source_clusters = (
+        [int(x.strip()) for x in clusters_raw.split(",") if x.strip()]
+        if clusters_raw
+        else list(SN_SOURCE_CLUSTERS)
+    )
+    bpc_raw = result.get("brokers_per_cluster", "")
+    result["source_clusters"] = source_clusters
+    result["brokers_per_cluster"] = int(bpc_raw) if bpc_raw else SN_BROKERS_PER_CLUSTER
+    for port in source_clusters:
+        result[f"link_name_{port}"] = f"{result['link_name']}-{port}"
     return result
 
 
@@ -54,8 +65,9 @@ def list_source_topics(
     cert_path: str,
     key_path: str,
     filter_prefix: str = None,
+    brokers_per_cluster: int = SN_BROKERS_PER_CLUSTER,
 ) -> list:
-    bootstrap = ",".join(f"{host}:{base_port + i}" for i in range(SN_BROKERS_PER_CLUSTER))
+    bootstrap = ",".join(f"{host}:{base_port + i}" for i in range(brokers_per_cluster))
     try:
         consumer = KafkaConsumer(
             bootstrap_servers=bootstrap,
@@ -81,7 +93,9 @@ def list_source_topics(
 
 def get_mirrored_source_topics(cfg: dict) -> set:
     source_names = set()
-    for link_key, prefix in [("link_name_4100", "4100."), ("link_name_4200", "4200.")]:
+    for port in cfg.get("source_clusters", SN_SOURCE_CLUSTERS):
+        link_key = f"link_name_{port}"
+        prefix = f"{port}."
         result = subprocess.run(
             [
                 "confluent", "kafka", "mirror", "list",
@@ -107,8 +121,8 @@ def get_mirrored_source_topics(cfg: dict) -> set:
 
 
 def enable_auto_mirror(cfg: dict, dry_run: bool) -> None:
-    for link_key in ("link_name_4100", "link_name_4200"):
-        link = cfg[link_key]
+    for port in cfg.get("source_clusters", SN_SOURCE_CLUSTERS):
+        link = cfg[f"link_name_{port}"]
         cmd = [
             "confluent", "kafka", "link", "configuration", "update", link,
             "--environment", cfg["environment_id"],
@@ -128,8 +142,9 @@ def enable_auto_mirror(cfg: dict, dry_run: bool) -> None:
 
 def create_mirror_topics(cfg: dict, topics: list, dry_run: bool) -> list:
     failures = []
-    for link_key, prefix in [("link_name_4100", "4100."), ("link_name_4200", "4200.")]:
-        link = cfg[link_key]
+    for port in cfg.get("source_clusters", SN_SOURCE_CLUSTERS):
+        link = cfg[f"link_name_{port}"]
+        prefix = f"{port}."
         for topic in topics:
             dest = f"{prefix}{topic}"
             cmd = [
@@ -213,7 +228,8 @@ def main() -> None:
 
     effective_filter = args.filter or cfg["instance_name"]
     topics = list_source_topics(
-        cfg["source_host"], 4100, ca, cert, key, filter_prefix=effective_filter
+        cfg["source_host"], cfg["source_clusters"][0], ca, cert, key,
+        filter_prefix=effective_filter, brokers_per_cluster=cfg["brokers_per_cluster"],
     )
 
     if not topics:
@@ -237,11 +253,11 @@ def main() -> None:
         print("No topics selected.")
         return
 
-    print(f"\nWill create {len(selected)} mirror topic(s) on "
-          f"{cfg['link_name_4100']} and {cfg['link_name_4200']}:")
+    link_names = " and ".join(cfg[f"link_name_{port}"] for port in cfg["source_clusters"])
+    print(f"\nWill create {len(selected)} mirror topic(s) on {link_names}:")
     for t in selected:
-        print(f"  4100.{t}  →  {cfg['link_name_4100']}")
-        print(f"  4200.{t}  →  {cfg['link_name_4200']}")
+        for port in cfg["source_clusters"]:
+            print(f"  {port}.{t}  →  {cfg[f'link_name_{port}']}")
 
     if not questionary.confirm("\nProceed?", default=False).ask():
         print("Aborted.")
@@ -255,7 +271,7 @@ def main() -> None:
             print(f"  {f}")
         sys.exit(1)
     elif not args.dry_run:
-        print(f"\nDone. {len(selected) * 2} mirror topic(s) created.")
+        print(f"\nDone. {len(selected) * len(cfg['source_clusters'])} mirror topic(s) created.")
 
 
 if __name__ == "__main__":

--- a/mirror-topics/tests/test_mirror_topics.py
+++ b/mirror-topics/tests/test_mirror_topics.py
@@ -34,6 +34,45 @@ def test_load_config_returns_dict_with_link_names(tmp_path):
     assert cfg["link_name_4200"] == "servicenow-link-4200"
 
 
+def test_load_config_defaults_source_clusters_and_brokers(tmp_path):
+    from mirror_topics import load_config, SN_SOURCE_CLUSTERS, SN_BROKERS_PER_CLUSTER
+    cfg = load_config(write_config(tmp_path))
+    assert cfg["source_clusters"] == SN_SOURCE_CLUSTERS
+    assert cfg["brokers_per_cluster"] == SN_BROKERS_PER_CLUSTER
+
+
+def test_load_config_reads_custom_source_clusters(tmp_path):
+    from mirror_topics import load_config
+    custom = textwrap.dedent("""\
+        [confluent]
+        environment_id  = env-abc123
+        cluster_id      = lkc-abc123
+        link_name       = servicenow-link
+        source_host     = kafka.example.com
+        instance_name   = snc.myinstance
+        source_clusters = 5000, 5100
+    """)
+    cfg = load_config(write_config(tmp_path, custom))
+    assert cfg["source_clusters"] == [5000, 5100]
+    assert cfg["link_name_5000"] == "servicenow-link-5000"
+    assert cfg["link_name_5100"] == "servicenow-link-5100"
+
+
+def test_load_config_reads_custom_brokers_per_cluster(tmp_path):
+    from mirror_topics import load_config
+    custom = textwrap.dedent("""\
+        [confluent]
+        environment_id      = env-abc123
+        cluster_id          = lkc-abc123
+        link_name           = servicenow-link
+        source_host         = kafka.example.com
+        instance_name       = snc.myinstance
+        brokers_per_cluster = 2
+    """)
+    cfg = load_config(write_config(tmp_path, custom))
+    assert cfg["brokers_per_cluster"] == 2
+
+
 def test_load_config_exits_if_missing():
     from mirror_topics import load_config
     with pytest.raises(SystemExit) as exc:


### PR DESCRIPTION
## Summary
- Moves `SN_SOURCE_CLUSTERS = [4100, 4200]` and `SN_BROKERS_PER_CLUSTER = 4` out of the scripts and into `link.conf` as optional keys
- Both default to existing values, so no config migration needed
- Allows changing cluster ports and broker count at runtime without editing code

## Test plan
- [ ] Existing configs with no new keys work identically (defaults apply)
- [ ] Setting `source_clusters = 5000, 5100` in link.conf creates links named `*-5000` and `*-5100`
- [ ] Setting `brokers_per_cluster = 2` generates a bootstrap string with 2 brokers per cluster
- [ ] All 35 cluster-link tests pass (`python -m pytest` from `cluster-link/`)
- [ ] All 19 mirror-topics tests pass (`python -m pytest` from `mirror-topics/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)