### PR TITLE
docs: add Confluent CLI as a requirement in root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A collection of CLI tools for integrating ServiceNow's Kafka infrastructure with
 
 > **Disclaimer:** This is personal work and is not supported, endorsed, or affiliated with ServiceNow or Confluent. Use at your own risk.
 
+## Requirements
+
+- **Confluent CLI** — required for cluster link and topic mirroring operations. [Download here](https://docs.confluent.io/confluent-cli/current/install.html)
+
 ## Tools
 
 | Tool | Description |


### PR DESCRIPTION
## Summary
- Adds a Requirements section to the root README listing the Confluent CLI with a download link — it's a prerequisite for cluster-link and mirror-topics but wasn't documented anywhere

## Test plan
- [ ] Verify the Requirements section renders correctly on GitHub
- [ ] Confirm the download link points to the official Confluent CLI install docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)