### PR TITLE
fix: single-cluster mode crashes with ValueError in create_link.py

### DIFF
--- a/cluster-link/create_link.py
+++ b/cluster-link/create_link.py
@@ -319,12 +319,14 @@ def main() -> None:
     #   4100.<topic>  — mirrored from the 4100 source cluster
     #   4200.<topic>  — mirrored from the 4200 source cluster
     # Downstream consumers subscribe to both and handle deduplication.
-    if "source_host" in cfg:
+    dual_cluster = "source_host" in cfg
+    if dual_cluster:
         links = [
             {
                 **cfg,
                 "link_name": f"{cfg['link_name']}-{port}",
                 "source_bootstrap": sn_bootstrap(cfg["source_host"], port, cfg["brokers_per_cluster"]),
+                "_port": port,
             }
             for port in cfg["source_clusters"]
         ]
@@ -332,12 +334,12 @@ def main() -> None:
         links = [cfg]
 
     for link_cfg in links:
-        port = int(link_cfg["link_name"].rsplit("-", 1)[1])
-        props = build_ssl_properties(
+        ssl_props = build_ssl_properties(
             ca_pem, client_cert, client_key,
             literal_newlines=args.literal_newlines,
             key_password=args.key_password,
-        ) + build_link_properties(port)
+        )
+        props = ssl_props + build_link_properties(link_cfg["_port"]) if dual_cluster else ssl_props
 
         tmp = tempfile.NamedTemporaryFile(
             mode="w", suffix=".properties", delete=False, encoding="utf-8"

--- a/cluster-link/tests/test_create_link.py
+++ b/cluster-link/tests/test_create_link.py
@@ -432,3 +432,69 @@ def test_dual_link_properties_include_4200_prefix():
     from create_link import build_link_properties
     props = build_link_properties(4200)
     assert "cluster.link.prefix=4200." in props
+
+
+# ---------------------------------------------------------------------------
+# single-cluster vs dual-cluster link expansion (regression for issue #14)
+# ---------------------------------------------------------------------------
+
+def test_single_cluster_mode_does_not_crash_or_add_prefix(tmp_path, capsys):
+    """source_bootstrap mode must not try to extract a port from link_name."""
+    from create_link import main
+    cfg_text = textwrap.dedent("""\
+        [confluent]
+        environment_id   = env-abc123
+        cluster_id       = lkc-abc123
+        link_name        = my-link
+        source_bootstrap = broker.example.com:9093
+    """)
+    (tmp_path / "link.conf").write_text(cfg_text)
+    (tmp_path / "ca.pem").write_bytes(b"CA")
+    (tmp_path / "client-cert.pem").write_bytes(b"CERT")
+    (tmp_path / "client-key.pem").write_bytes(b"KEY")
+
+    mock_run = MagicMock(returncode=0, stdout="", stderr="")
+    with patch("sys.argv", [
+        "create_link.py",
+        "--config", str(tmp_path / "link.conf"),
+        "--pem-dir", str(tmp_path),
+        "--dry-run",
+    ]):
+        with patch("create_link.check_confluent_cli"):
+            with patch("create_link.check_auth"):
+                with patch("subprocess.run", return_value=mock_run):
+                    main()  # must not raise ValueError / IndexError
+
+    out = capsys.readouterr().out
+    assert "cluster.link.prefix" not in out
+
+
+def test_dual_cluster_mode_adds_port_prefix(tmp_path, capsys):
+    """source_host mode must add cluster.link.prefix for each port."""
+    from create_link import main
+    cfg_text = textwrap.dedent("""\
+        [confluent]
+        environment_id = env-abc123
+        cluster_id     = lkc-abc123
+        link_name      = my-link
+        source_host    = kafka.example.com
+        source_clusters = 4100, 4200
+    """)
+    (tmp_path / "link.conf").write_text(cfg_text)
+    (tmp_path / "ca.pem").write_bytes(b"CA")
+    (tmp_path / "client-cert.pem").write_bytes(b"CERT")
+    (tmp_path / "client-key.pem").write_bytes(b"KEY")
+
+    with patch("sys.argv", [
+        "create_link.py",
+        "--config", str(tmp_path / "link.conf"),
+        "--pem-dir", str(tmp_path),
+        "--dry-run",
+    ]):
+        with patch("create_link.check_confluent_cli"):
+            with patch("create_link.check_auth"):
+                main()  # must not raise
+
+    out = capsys.readouterr().out
+    assert "4100" in out
+    assert "4200" in out


### PR DESCRIPTION
## Summary
- `create_link.py` line 335 unconditionally called `link_name.rsplit("-", 1)[1]` to extract a port number, but in single-cluster mode (`source_bootstrap`) the link name has no port suffix — this crashed with `ValueError`/`IndexError`
- Port extraction and `build_link_properties()` (which adds `cluster.link.prefix=<port>.`) are now guarded behind a `dual_cluster` flag that is only set when `source_host` is present
- Single-cluster links no longer get a `cluster.link.prefix` property, which was also semantically wrong

## Test plan
- [ ] `python -m pytest tests/` in `cluster-link/` — 37 tests pass including 2 new regression tests
- [ ] `test_single_cluster_mode_does_not_crash_or_add_prefix` — verifies no crash and no prefix in dry-run output
- [ ] `test_dual_cluster_mode_adds_port_prefix` — verifies 4100/4200 prefixes still appear in dual-cluster mode

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)