### PR TITLE
fix: guard filter flags against missing --all; test live filter path

### DIFF
--- a/mirror-topics/mirror_topics.py
+++ b/mirror-topics/mirror_topics.py
@@ -269,6 +269,10 @@ def main() -> None:
                         help="Print commands without executing")
     args = parser.parse_args()
 
+    filter_args = [args.include_prefixes, args.exclude_prefixes, args.include_topics, args.exclude_topics]
+    if any(filter_args) and not args.all:
+        parser.error("--include-prefixes, --exclude-prefixes, --include-topics, and --exclude-topics require --all")
+
     cfg = load_config(args.config)
     check_confluent_cli()
     check_auth(cfg["environment_id"], cfg["cluster_id"])

--- a/mirror-topics/tests/test_mirror_topics.py
+++ b/mirror-topics/tests/test_mirror_topics.py
@@ -262,6 +262,32 @@ def test_enable_auto_mirror_with_filters_includes_filter_config(capsys):
     assert "PREFIXED" in out
 
 
+def test_enable_auto_mirror_with_filters_live_run_passes_config_file_and_cleans_up():
+    import os
+    from mirror_topics import enable_auto_mirror
+    cfg = {
+        "link_name_4100": "servicenow-link-4100",
+        "link_name_4200": "servicenow-link-4200",
+        "environment_id": "env-abc123",
+        "cluster_id": "lkc-abc123",
+    }
+    config_paths = []
+
+    def capture_config_path(cmd, **kwargs):
+        config_idx = cmd.index("--config") + 1
+        config_paths.append(cmd[config_idx])
+        return MagicMock(returncode=0, stdout="Updated.")
+
+    with patch("subprocess.run", side_effect=capture_config_path):
+        enable_auto_mirror(cfg, dry_run=False, include_prefixes=["snc.hermes1"])
+
+    assert len(config_paths) == 2
+    for path in config_paths:
+        assert path.endswith(".properties")
+        # temp file must be deleted after the call
+        assert not os.path.exists(path)
+
+
 # ---------------------------------------------------------------------------
 # build_mirror_filters
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds a `parser.error()` check so `--include-prefixes`, `--exclude-prefixes`, `--include-topics`, and `--exclude-topics` fail loudly when `--all` is absent, rather than silently ignoring the flags
- Adds a non-dry-run test for `enable_auto_mirror` with filters that verifies subprocess receives a `.properties` file path (not inline JSON) and that the temp file is cleaned up after the call

## Test plan
- [ ] Run `pytest` from `mirror-topics/` — all tests pass
- [ ] `python mirror_topics.py --include-prefixes foo` (no `--all`) exits with a clear error
- [ ] `python mirror_topics.py --all --include-prefixes foo --dry-run` runs normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)