### PR TITLE
Fix/kafka consumer cleanup

### DIFF
--- a/sn_confluent/mirror/main.py
+++ b/sn_confluent/mirror/main.py
@@ -28,6 +28,9 @@ from sn_confluent.core.config import (
 from kafka import KafkaConsumer
 
 INTERNAL_TOPIC_PREFIXES = ("__", "_confluent")
+KAFKA_REQUEST_TIMEOUT_MS = 30_000
+KAFKA_METADATA_MAX_AGE_MS = 10_000
+KAFKA_CONNECTIONS_MAX_IDLE_MS = 30_000
 
 REQUIRED_KEYS = ("environment_id", "cluster_id", "link_name", "source_host", "instance_name")
 
@@ -57,6 +60,9 @@ def list_source_topics(
             ssl_cafile=ca_path,
             ssl_certfile=cert_path,
             ssl_keyfile=key_path,
+            request_timeout_ms=KAFKA_REQUEST_TIMEOUT_MS,
+            metadata_max_age_ms=KAFKA_METADATA_MAX_AGE_MS,
+            connections_max_idle_ms=KAFKA_CONNECTIONS_MAX_IDLE_MS,
         )
         try:
             raw_topics = consumer.topics()

--- a/sn_confluent/mirror/main.py
+++ b/sn_confluent/mirror/main.py
@@ -58,8 +58,10 @@ def list_source_topics(
             ssl_certfile=cert_path,
             ssl_keyfile=key_path,
         )
-        raw_topics = consumer.topics()
-        consumer.close()
+        try:
+            raw_topics = consumer.topics()
+        finally:
+            consumer.close()
     except Exception as exc:
         print(f"Error: Failed to connect to source brokers: {exc}", file=sys.stderr)
         sys.exit(1)

--- a/sn_confluent/mirror/tests/test_mirror.py
+++ b/sn_confluent/mirror/tests/test_mirror.py
@@ -148,6 +148,16 @@ def test_list_source_topics_exits_on_connection_error(capsys):
     assert "Connection refused" in capsys.readouterr().err
 
 
+def test_list_source_topics_closes_consumer_on_topics_error():
+    from mirror_topics import list_source_topics
+    mock_consumer = MagicMock()
+    mock_consumer.topics.side_effect = Exception("Connection refused")
+    with patch("mirror_topics.KafkaConsumer", return_value=mock_consumer):
+        with pytest.raises(SystemExit):
+            list_source_topics("kafka.example.com", 4100, "ca", "cert", "key")
+    mock_consumer.close.assert_called_once()
+
+
 # ---------------------------------------------------------------------------
 # get_mirrored_source_topics
 # ---------------------------------------------------------------------------

--- a/sn_confluent/mirror/tests/test_mirror.py
+++ b/sn_confluent/mirror/tests/test_mirror.py
@@ -149,13 +149,36 @@ def test_list_source_topics_exits_on_connection_error(capsys):
 
 
 def test_list_source_topics_closes_consumer_on_topics_error():
-    from mirror_topics import list_source_topics
+    from sn_confluent.mirror.main import list_source_topics
     mock_consumer = MagicMock()
     mock_consumer.topics.side_effect = Exception("Connection refused")
-    with patch("mirror_topics.KafkaConsumer", return_value=mock_consumer):
+    with patch("sn_confluent.mirror.main.KafkaConsumer", return_value=mock_consumer):
         with pytest.raises(SystemExit):
             list_source_topics("kafka.example.com", 4100, "ca", "cert", "key")
     mock_consumer.close.assert_called_once()
+
+
+def test_list_source_topics_sets_kafka_timeouts():
+    from sn_confluent.mirror.main import (
+        KAFKA_CONNECTIONS_MAX_IDLE_MS,
+        KAFKA_METADATA_MAX_AGE_MS,
+        KAFKA_REQUEST_TIMEOUT_MS,
+        list_source_topics,
+    )
+    mock_consumer = MagicMock()
+    mock_consumer.topics.return_value = {"alpha"}
+    with patch("sn_confluent.mirror.main.KafkaConsumer", return_value=mock_consumer) as kafka_consumer:
+        list_source_topics("kafka.example.com", 4100, "ca", "cert", "key")
+    kafka_consumer.assert_called_once_with(
+        bootstrap_servers="kafka.example.com:4100,kafka.example.com:4101,kafka.example.com:4102,kafka.example.com:4103",
+        security_protocol="SSL",
+        ssl_cafile="ca",
+        ssl_certfile="cert",
+        ssl_keyfile="key",
+        request_timeout_ms=KAFKA_REQUEST_TIMEOUT_MS,
+        metadata_max_age_ms=KAFKA_METADATA_MAX_AGE_MS,
+        connections_max_idle_ms=KAFKA_CONNECTIONS_MAX_IDLE_MS,
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes a connection leak in `list_source_topics`: if `consumer.topics()` raised, the outer `except` would call `sys.exit(1)` without ever calling `consumer.close()`. Wraps the call in `try/finally` to guarantee cleanup.

Also extracts three Kafka timeout constants (`request_timeout_ms`, `metadata_max_age_ms`, `connections_max_idle_ms`) and passes them to `KafkaConsumer` to avoid hanging on unresponsive brokers.

**Tests added:**
- `test_list_source_topics_closes_consumer_on_topics_error` — asserts `close()` is called when `topics()` raises
- `test_list_source_topics_sets_kafka_timeouts` — asserts timeout constants are forwarded to the constructor