### PR TITLE
fix: replace --key-password flag with env var + getpass (issue #16)

### DIFF
--- a/sn_confluent/extract/main.py
+++ b/sn_confluent/extract/main.py
@@ -3,7 +3,12 @@
 Outputs (written to --out-dir):
   ca.pem          — CA certificates from truststore (upload to Confluent Cloud)
   client-cert.pem — Client certificate chain from keystore (leaf + intermediates)
-  client-key.pem  — Client private key from keystore (PKCS8; encrypted if --key-password given)
+  client-key.pem  — Client private key from keystore (PKCS8; encrypted if KEY_PASSWORD set)
+
+Key encryption password resolution order:
+  1. KEY_PASSWORD environment variable (non-interactive / CI)
+  2. Interactive prompt via getpass (terminal use)
+  Set to empty string or omit to produce an unencrypted private key.
 """
 
 import argparse
@@ -98,6 +103,15 @@ def set_key_permissions(path: str) -> None:
         )
 
 
+def _resolve_key_password() -> str | None:
+    """Return the key encryption password from env var or interactive prompt."""
+    pw = os.environ.get("KEY_PASSWORD")
+    if pw is not None:
+        return pw or None
+    entered = getpass.getpass("Key encryption password (Enter to skip): ")
+    return entered or None
+
+
 def _write(path: str, data: bytes) -> None:
     with open(path, "wb") as fh:
         fh.write(data)
@@ -119,17 +133,14 @@ def main(argv: Optional[List[str]] = None) -> int:
         "--out-dir", default=".",
         help="Directory to write output PEM files (default: ./)",
     )
-    parser.add_argument(
-        "--key-password", default=None, metavar="PASSWORD",
-        help="Encrypt the output private key with this password (adds ssl.key.password support)",
-    )
     args = parser.parse_args(argv)
 
     password = getpass.getpass("Keystore password: ")
+    key_password = _resolve_key_password()
 
     ca_pem = extract_ca_pem(args.truststore, password)
     client_cert_pem = extract_client_cert_pem(args.keystore, password)
-    client_key_pem = extract_client_key_pem(args.keystore, password, args.key_password)
+    client_key_pem = extract_client_key_pem(args.keystore, password, key_password)
 
     ca_path = os.path.join(args.out_dir, "ca.pem")
     cert_path = os.path.join(args.out_dir, "client-cert.pem")

--- a/sn_confluent/extract/tests/test_extract.py
+++ b/sn_confluent/extract/tests/test_extract.py
@@ -198,6 +198,43 @@ def test_set_key_permissions_warns_on_windows(capsys):
 
 
 # ---------------------------------------------------------------------------
+# _resolve_key_password
+# ---------------------------------------------------------------------------
+
+def test_resolve_key_password_uses_env_var(monkeypatch):
+    from sn_confluent.extract.main import _resolve_key_password
+    monkeypatch.setenv("KEY_PASSWORD", "env-secret")
+    assert _resolve_key_password() == "env-secret"
+
+
+def test_resolve_key_password_env_var_empty_returns_none(monkeypatch):
+    from sn_confluent.extract.main import _resolve_key_password
+    monkeypatch.setenv("KEY_PASSWORD", "")
+    assert _resolve_key_password() is None
+
+
+def test_resolve_key_password_prompts_when_env_unset(monkeypatch):
+    from sn_confluent.extract.main import _resolve_key_password
+    monkeypatch.delenv("KEY_PASSWORD", raising=False)
+    monkeypatch.setattr("getpass.getpass", lambda _prompt: "typed-secret")
+    assert _resolve_key_password() == "typed-secret"
+
+
+def test_resolve_key_password_prompt_empty_returns_none(monkeypatch):
+    from sn_confluent.extract.main import _resolve_key_password
+    monkeypatch.delenv("KEY_PASSWORD", raising=False)
+    monkeypatch.setattr("getpass.getpass", lambda _prompt: "")
+    assert _resolve_key_password() is None
+
+
+def test_resolve_key_password_env_var_skips_prompt(monkeypatch):
+    from sn_confluent.extract.main import _resolve_key_password
+    monkeypatch.setenv("KEY_PASSWORD", "env-secret")
+    monkeypatch.setattr("getpass.getpass", lambda _prompt: (_ for _ in ()).throw(AssertionError("getpass must not be called when env var is set")))
+    assert _resolve_key_password() == "env-secret"
+
+
+# ---------------------------------------------------------------------------
 # load_p12 error handling
 # ---------------------------------------------------------------------------
 

--- a/sn_confluent/link/main.py
+++ b/sn_confluent/link/main.py
@@ -9,6 +9,7 @@
 #   3. link.conf filled in with your environment/cluster IDs
 
 import argparse
+import getpass
 import json
 import os
 import subprocess
@@ -32,6 +33,15 @@ from sn_confluent.core.pem import (
 
 
 REQUIRED_KEYS = ["environment_id", "cluster_id", "link_name"]
+
+
+def _resolve_key_password() -> str | None:
+    """Return the key encryption password from env var or interactive prompt."""
+    pw = os.environ.get("KEY_PASSWORD")
+    if pw is not None:
+        return pw or None
+    entered = getpass.getpass("Key encryption password (Enter to skip): ")
+    return entered or None
 
 
 def sn_bootstrap(host: str, base_port: int, brokers_per_cluster: int = SN_BROKERS_PER_CLUSTER) -> str:
@@ -230,19 +240,16 @@ def main(argv: Optional[List[str]] = None) -> int:
         "--literal-newlines", action="store_true",
         help="Use actual newlines in PEM values instead of \\\\n escapes (try this if the web console rejects the default format)",
     )
-    parser.add_argument(
-        "--key-password", default=None, metavar="PASSWORD",
-        help="Password for an encrypted private key; adds ssl.key.password to the properties",
-    )
     args = parser.parse_args(argv)
 
     cfg = load_config(args.config)
     ca_pem, client_cert, client_key = load_pem_files(args.pem_dir)
+    key_password = _resolve_key_password()
 
     if args.copy_config:
         ssl_props = build_ssl_properties(ca_pem, client_cert, client_key,
                                          literal_newlines=args.literal_newlines,
-                                         key_password=args.key_password)
+                                         key_password=key_password)
         copy_security_config(ssl_props)
         return 0
 
@@ -274,7 +281,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         ssl_props = build_ssl_properties(
             ca_pem, client_cert, client_key,
             literal_newlines=args.literal_newlines,
-            key_password=args.key_password,
+            key_password=key_password,
         )
         props = ssl_props + build_link_properties(link_cfg["_port"]) if dual_cluster else ssl_props
 

--- a/sn_confluent/link/tests/test_link.py
+++ b/sn_confluent/link/tests/test_link.py
@@ -460,10 +460,11 @@ def test_single_cluster_mode_does_not_crash_or_add_prefix(tmp_path, capsys):
         "--pem-dir", str(tmp_path),
         "--dry-run",
     ]):
-        with patch("sn_confluent.link.main.check_confluent_cli"):
-            with patch("sn_confluent.link.main.check_auth"):
-                with patch("subprocess.run", return_value=mock_run):
-                    main()  # must not raise ValueError / IndexError
+        with patch("sn_confluent.link.main._resolve_key_password", return_value=None):
+            with patch("sn_confluent.link.main.check_confluent_cli"):
+                with patch("sn_confluent.link.main.check_auth"):
+                    with patch("subprocess.run", return_value=mock_run):
+                        main()  # must not raise ValueError / IndexError
 
     out = capsys.readouterr().out
     assert "cluster.link.prefix" not in out
@@ -491,10 +492,48 @@ def test_dual_cluster_mode_adds_port_prefix(tmp_path, capsys):
         "--pem-dir", str(tmp_path),
         "--dry-run",
     ]):
-        with patch("sn_confluent.link.main.check_confluent_cli"):
-            with patch("sn_confluent.link.main.check_auth"):
-                main()  # must not raise
+        with patch("sn_confluent.link.main._resolve_key_password", return_value=None):
+            with patch("sn_confluent.link.main.check_confluent_cli"):
+                with patch("sn_confluent.link.main.check_auth"):
+                    main()  # must not raise
 
     out = capsys.readouterr().out
     assert "4100" in out
     assert "4200" in out
+
+
+# ---------------------------------------------------------------------------
+# _resolve_key_password
+# ---------------------------------------------------------------------------
+
+def test_resolve_key_password_uses_env_var(monkeypatch):
+    from sn_confluent.link.main import _resolve_key_password
+    monkeypatch.setenv("KEY_PASSWORD", "env-secret")
+    assert _resolve_key_password() == "env-secret"
+
+
+def test_resolve_key_password_env_var_empty_returns_none(monkeypatch):
+    from sn_confluent.link.main import _resolve_key_password
+    monkeypatch.setenv("KEY_PASSWORD", "")
+    assert _resolve_key_password() is None
+
+
+def test_resolve_key_password_prompts_when_env_unset(monkeypatch):
+    from sn_confluent.link.main import _resolve_key_password
+    monkeypatch.delenv("KEY_PASSWORD", raising=False)
+    monkeypatch.setattr("getpass.getpass", lambda _prompt: "typed-secret")
+    assert _resolve_key_password() == "typed-secret"
+
+
+def test_resolve_key_password_prompt_empty_returns_none(monkeypatch):
+    from sn_confluent.link.main import _resolve_key_password
+    monkeypatch.delenv("KEY_PASSWORD", raising=False)
+    monkeypatch.setattr("getpass.getpass", lambda _prompt: "")
+    assert _resolve_key_password() is None
+
+
+def test_resolve_key_password_env_var_skips_prompt(monkeypatch):
+    from sn_confluent.link.main import _resolve_key_password
+    monkeypatch.setenv("KEY_PASSWORD", "env-secret")
+    monkeypatch.setattr("getpass.getpass", lambda _prompt: (_ for _ in ()).throw(AssertionError("getpass must not be called when env var is set")))
+    assert _resolve_key_password() == "env-secret"


### PR DESCRIPTION
## Summary

- Removes `--key-password` CLI flag from `sn-confluent extract` and `sn-confluent link` — it exposed the credential in `ps aux`, shell history, and CI logs
- Replaces it with a two-path resolution chain in each module: `KEY_PASSWORD` env var (non-interactive/CI) → `getpass.getpass()` interactive prompt (terminal use)
- Empty env var or empty prompt both resolve to `None` (unencrypted output key)
- Updated two pre-existing `main()` integration tests in `link` that now need `_resolve_key_password` patched

## Behavior

| Scenario | Before | After |
|---|---|---|
| CI / scripting | `--key-password $SECRET` (exposed in argv) | `KEY_PASSWORD=$SECRET sn-confluent ...` |
| Interactive terminal | `--key-password <typed>` | prompted securely via `getpass` |
| No password needed | omit flag | press Enter at prompt, or `KEY_PASSWORD=""` |

## Test plan

- [ ] `pytest sn_confluent/extract/tests/ sn_confluent/link/tests/ -v` → 61 passed
- [ ] `sn-confluent extract --key-password secret` → `error: unrecognized arguments: --key-password secret`
- [ ] `KEY_PASSWORD=secret sn-confluent extract ...` → uses password without prompting
- [ ] `sn-confluent extract ...` (no env var) → prompts interactively

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)