### PR TITLE
fix: remove --key-password flag from replicate (issue #16 follow-up)

### DIFF
--- a/sn_confluent/replicate/main.py
+++ b/sn_confluent/replicate/main.py
@@ -56,20 +56,13 @@ def load_config(path: str) -> dict:
     return result
 
 
-def resolve_key_password(client_key_bytes: bytes, cli_password: str | None) -> str | None:
-    """Resolve the private key password from env, interactive prompt, or CLI flag."""
-    env_pw = os.environ.get("REPLICATOR_KEY_PASSWORD")
-    if env_pw:
-        return env_pw
+def resolve_key_password(client_key_bytes: bytes) -> str | None:
+    """Resolve the private key password from env var or interactive prompt."""
+    env_pw = os.environ.get("KEY_PASSWORD")
+    if env_pw is not None:
+        return env_pw or None
     if b"ENCRYPTED" in client_key_bytes:
         return getpass.getpass("Private key is encrypted. Enter password: ")
-    if cli_password:
-        print(
-            "Warning: --key-password passes the password via command line. "
-            "It may appear in shell history.",
-            file=sys.stderr,
-        )
-        return cli_password
     return None
 
 
@@ -396,10 +389,6 @@ def main(argv: Optional[List[str]] = None) -> int:
         help="Connect REST endpoint override",
     )
     parser.add_argument(
-        "--key-password", default=None, metavar="PASSWORD",
-        help="Private key password (warning: visible in shell history)",
-    )
-    parser.add_argument(
         "--timeout", type=int, default=120,
         help="Per-connector poll timeout in seconds (default: 120)",
     )
@@ -430,7 +419,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     ca_pem, client_cert, client_key = load_pem_files(pem_dir)
 
     # 4. Resolve key password
-    key_password = resolve_key_password(client_key, args.key_password)
+    key_password = resolve_key_password(client_key)
 
     # 5. Resolve direction
     direction = args.direction or cfg.get("direction", "cc-to-sn")

--- a/sn_confluent/replicate/tests/test_replicate.py
+++ b/sn_confluent/replicate/tests/test_replicate.py
@@ -436,3 +436,39 @@ def test_topics_flag_produces_correct_regex(mock_cli_check, mock_urlopen):
                 sr.main()
         output = captured.getvalue()
     assert "^(t1|t2)$" in output
+
+
+# ---------------------------------------------------------------------------
+# resolve_key_password
+# ---------------------------------------------------------------------------
+
+UNENCRYPTED_KEY = b"-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n"
+ENCRYPTED_KEY = b"-----BEGIN ENCRYPTED PRIVATE KEY-----\nfake\n-----END ENCRYPTED PRIVATE KEY-----\n"
+
+
+def test_resolve_key_password_uses_env_var(monkeypatch):
+    monkeypatch.setenv("KEY_PASSWORD", "env-secret")
+    assert sr.resolve_key_password(UNENCRYPTED_KEY) == "env-secret"
+
+
+def test_resolve_key_password_env_var_empty_returns_none(monkeypatch):
+    monkeypatch.setenv("KEY_PASSWORD", "")
+    assert sr.resolve_key_password(UNENCRYPTED_KEY) is None
+
+
+def test_resolve_key_password_env_var_skips_prompt(monkeypatch):
+    monkeypatch.setenv("KEY_PASSWORD", "env-secret")
+    monkeypatch.setattr("getpass.getpass", lambda _: (_ for _ in ()).throw(AssertionError("getpass must not be called")))
+    assert sr.resolve_key_password(ENCRYPTED_KEY) == "env-secret"
+
+
+def test_resolve_key_password_prompts_when_key_encrypted(monkeypatch):
+    monkeypatch.delenv("KEY_PASSWORD", raising=False)
+    monkeypatch.setattr("getpass.getpass", lambda _: "typed-secret")
+    assert sr.resolve_key_password(ENCRYPTED_KEY) == "typed-secret"
+
+
+def test_resolve_key_password_no_prompt_for_unencrypted_key(monkeypatch):
+    monkeypatch.delenv("KEY_PASSWORD", raising=False)
+    monkeypatch.setattr("getpass.getpass", lambda _: (_ for _ in ()).throw(AssertionError("getpass must not be called for unencrypted key")))
+    assert sr.resolve_key_password(UNENCRYPTED_KEY) is None


### PR DESCRIPTION
## Summary

- Removes `--key-password` CLI flag from `sn-confluent replicate`, completing the argv exposure fix from #35
- Drops the `cli_password` parameter from `resolve_key_password()` entirely — no more flag fallback
- Renames env var from `REPLICATOR_KEY_PASSWORD` → `KEY_PASSWORD` to match `extract` and `link`
- Prompt only fires when the key is actually encrypted (`ENCRYPTED` in key bytes) — no unnecessary interruption for unencrypted keys

## Behavior

| Scenario | Before | After |
|---|---|---|
| CI / scripting | `--key-password $SECRET` (exposed in argv) | `KEY_PASSWORD=$SECRET sn-confluent replicate ...` |
| Encrypted key, interactive | prompted via getpass | same |
| Unencrypted key | no prompt | same — getpass not called |

## Test plan

- [ ] `pytest sn_confluent/replicate/tests/ -v` → 36 passed
- [ ] `sn-confluent replicate --key-password secret` → `error: unrecognized arguments`
- [ ] `KEY_PASSWORD=secret sn-confluent replicate ...` → uses password without prompting

🤖 Generated with [Claude Code](https://claude.com/claude-code)