### PR TITLE
docs: update READMEs for KEY_PASSWORD env var (replaces --key-password flag)

### DIFF
--- a/sn_confluent/extract/README.md
+++ b/sn_confluent/extract/README.md
@@ -32,17 +32,20 @@ Prompts once for the keystore password, then writes:
 | `--keystore PATH` | `./keystore` | Path to PKCS12 keystore |
 | `--truststore PATH` | `./truststore` | Path to PKCS12 truststore |
 | `--out-dir PATH` | `./` | Directory to write PEM files |
-| `--key-password PASSWORD` | none | Encrypt the output private key with this password |
 
 ### Encrypted key output
 
-If your Confluent Cloud cluster requires `ssl.key.password`, pass `--key-password` to produce an encrypted PKCS8 key:
+If your Confluent Cloud cluster requires `ssl.key.password`, set `KEY_PASSWORD` to produce an encrypted PKCS8 key:
 
 ```bash
-python extract_pem.py --key-password yourpassword
+# Non-interactive (CI / scripting)
+KEY_PASSWORD=yourpassword sn-confluent extract
+
+# Interactive — omit the env var and you'll be prompted
+sn-confluent extract
 ```
 
-Then supply the same password to `create_link.py --key-password`.
+Supply the same password when running `sn-confluent link`.
 
 ## Tests
 

--- a/sn_confluent/link/README.md
+++ b/sn_confluent/link/README.md
@@ -53,11 +53,16 @@ python create_link.py --pem-dir /path/to/pems
 |---|---|---|
 | `--config PATH` | `./link.conf` | Path to config file |
 | `--pem-dir PATH` | `./` | Directory containing PEM files |
-| `--key-password PASSWORD` | none | Password for encrypted private key; adds `ssl.key.password` |
 | `--timeout SECS` | `60` | Seconds to wait for `ACTIVE` state |
 | `--dry-run` | off | Print CLI command without executing |
 | `--copy-config` | off | Copy SSL properties to clipboard for pasting into the web console |
 | `--literal-newlines` | off | Use actual newlines in PEM values instead of `\n` escapes |
+
+If your private key is encrypted, set `KEY_PASSWORD` before running (non-interactive) or omit it to be prompted:
+
+```bash
+KEY_PASSWORD=yourpassword sn-confluent link
+```
 
 ### Web console path
 

--- a/sn_confluent/replicate/README.md
+++ b/sn_confluent/replicate/README.md
@@ -102,16 +102,19 @@ python setup_replicator.py --connect-url http://my-worker:8083
 | `--all` | off | Replicate all topics (skips wizard) |
 | `--no-wizard` | off | Disable interactive topic picker |
 | `--connect-url URL` | `http://localhost:8083` | Connect worker REST endpoint |
-| `--key-password PW` | none | Password for encrypted private key (prefer env var) |
 | `--dry-run` | off | Print connector config JSON without creating |
 
 ## Private key password
 
-If your `client-key.pem` is encrypted, provide the password in one of three ways (listed by preference):
+If your `client-key.pem` is encrypted, provide the password via the `KEY_PASSWORD` environment variable (non-interactive) or omit it to be prompted automatically when the key is detected as encrypted:
 
-1. **Environment variable** (recommended): `export REPLICATOR_KEY_PASSWORD=...`
-2. **Interactive prompt**: the script asks automatically when the key is encrypted
-3. **CLI flag**: `--key-password SECRET` -- works but the password is visible in shell history
+```bash
+# Non-interactive (CI / scripting)
+KEY_PASSWORD=yourpassword sn-confluent replicate
+
+# Interactive — prompted only if the key is encrypted
+sn-confluent replicate
+```
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Follows up on #35 and #36. Removes all `--key-password` flag references from the three affected READMEs and documents the `KEY_PASSWORD` env var + interactive prompt pattern.

- `extract/README.md` — replaced flag row and example with env var usage
- `link/README.md` — removed flag row; added `KEY_PASSWORD` note before the web console section
- `replicate/README.md` — removed flag row and rewrote the "Private key password" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)