### PR TITLE
ci: add GitHub Actions pytest workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest sn_confluent/ -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4
@@ -20,6 +20,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: "pip"
 
       - name: Install dependencies
         run: |

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # sn-confluent
 
+[![CI](https://github.com/wiz0floyd/servicenow-confluent-tools/actions/workflows/ci.yml/badge.svg)](https://github.com/wiz0floyd/servicenow-confluent-tools/actions/workflows/ci.yml)
+
 A unified CLI for integrating ServiceNow's Kafka infrastructure with Confluent Cloud.
 
 > **Disclaimer:** This is personal work and is not supported, endorsed, or affiliated with ServiceNow or Confluent. Use at your own risk.


### PR DESCRIPTION
Fixes #34

## Summary
- Added a GitHub Actions CI workflow for pushes and pull requests to `main`.
- Runs `pytest sn_confluent/ -v` on Python 3.9, 3.11, and 3.12.
- Added the CI workflow badge to the README.

## Tests
- `uv venv --python 3.12 .venv-verify`
- `uv pip install --python .venv-verify\Scripts\python.exe -e ".[dev]"`
- `.\.venv-verify\Scripts\python -m pytest sn_confluent/ -v` (`125 passed, 1 skipped`)