### PR TITLE
fix: replace X | None union syntax with Optional[X] for Python 3.9 compatibility

### DIFF
--- a/sn_confluent/extract/main.py
+++ b/sn_confluent/extract/main.py
@@ -103,7 +103,7 @@ def set_key_permissions(path: str) -> None:
         )
 
 
-def _resolve_key_password() -> str | None:
+def _resolve_key_password() -> Optional[str]:
     """Return the key encryption password from env var or interactive prompt."""
     pw = os.environ.get("KEY_PASSWORD")
     if pw is not None:

--- a/sn_confluent/link/main.py
+++ b/sn_confluent/link/main.py
@@ -35,7 +35,7 @@ from sn_confluent.core.pem import (
 REQUIRED_KEYS = ["environment_id", "cluster_id", "link_name"]
 
 
-def _resolve_key_password() -> str | None:
+def _resolve_key_password() -> Optional[str]:
     """Return the key encryption password from env var or interactive prompt."""
     pw = os.environ.get("KEY_PASSWORD")
     if pw is not None:

--- a/sn_confluent/mirror/main.py
+++ b/sn_confluent/mirror/main.py
@@ -116,7 +116,7 @@ def build_mirror_filters(
     exclude_prefixes: list = None,
     include_topics: list = None,
     exclude_topics: list = None,
-) -> str | None:
+) -> Optional[str]:
     """Build the auto.create.mirror.topics.filters JSON value, or None if no filters given."""
     entries = []
     for name in (include_prefixes or []):

--- a/sn_confluent/replicate/main.py
+++ b/sn_confluent/replicate/main.py
@@ -56,7 +56,7 @@ def load_config(path: str) -> dict:
     return result
 
 
-def resolve_key_password(client_key_bytes: bytes) -> str | None:
+def resolve_key_password(client_key_bytes: bytes) -> Optional[str]:
     """Resolve the private key password from env var or interactive prompt."""
     env_pw = os.environ.get("KEY_PASSWORD")
     if env_pw is not None:
@@ -119,7 +119,7 @@ def list_sn_topics(
     ca_pem_bytes: bytes,
     client_cert_bytes: bytes,
     client_key_bytes: bytes,
-    key_password: str | None,
+    key_password: Optional[str],
 ) -> list[str]:
     """List topics on SN Hermes via kafka-python AdminClient."""
     try:
@@ -156,7 +156,7 @@ def list_sn_topics(
     return sorted(t for t in raw if not t.startswith("__") and not t.startswith("_confluent"))
 
 
-def build_topic_regex(topics: list[str] | None, use_all: bool) -> str:
+def build_topic_regex(topics: Optional[List[str]], use_all: bool) -> str:
     """Build topic.regex from selected topics or --all flag."""
     if use_all:
         return "(?!__)(?!_confluent).+"
@@ -178,7 +178,7 @@ def build_cc_to_sn_config(
     ca_pem: bytes,
     client_cert: bytes,
     client_key: bytes,
-    key_password: str | None,
+    key_password: Optional[str],
     group_id: str,
     topic_regex: str,
     topic_rename_format: str,
@@ -213,7 +213,7 @@ def build_sn_to_cc_configs(
     ca_pem: bytes,
     client_cert: bytes,
     client_key: bytes,
-    key_password: str | None,
+    key_password: Optional[str],
     group_id: str,
     topic_regex: str,
     topic_rename_format: str,


### PR DESCRIPTION
## Summary
- `str | None` and `list[str] | None` union syntax (PEP 604) requires Python 3.10+; using it in function signatures causes a `TypeError` at import time on Python 3.9
- Replaced all occurrences with `Optional[str]` / `Optional[List[str]]` from `typing`, which is already imported in each affected file
- Affected: `replicate/main.py` (4 occurrences), `extract/main.py`, `link/main.py`, `mirror/main.py`

## Test plan
- [ ] CI passes on Python 3.9 matrix job
- [ ] CI passes on Python 3.10/3.11 matrix jobs (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)