### PR TITLE
feat: warn loudly when no key encryption password is provided

### DIFF
--- a/sn_confluent/link/README.md
+++ b/sn_confluent/link/README.md
@@ -58,7 +58,7 @@ python create_link.py --pem-dir /path/to/pems
 | `--copy-config` | off | Copy SSL properties to clipboard for pasting into the web console |
 | `--literal-newlines` | off | Use actual newlines in PEM values instead of `\n` escapes |
 
-If your private key is encrypted, set `KEY_PASSWORD` before running (non-interactive) or omit it to be prompted:
+Set `KEY_PASSWORD` before running (non-interactive) or omit it to be prompted. **Omitting a key password in a production environment is a security risk** — the private key is stored unencrypted in Confluent Cloud cluster link configuration where any operator with environment access can retrieve it. A prominent warning is printed to stderr when no password is provided.
 
 ```bash
 KEY_PASSWORD=yourpassword sn-confluent link

--- a/sn_confluent/link/main.py
+++ b/sn_confluent/link/main.py
@@ -44,6 +44,25 @@ def _resolve_key_password() -> Optional[str]:
     return entered or None
 
 
+def warn_no_key_password() -> None:
+    """Print a loud security warning when no key encryption password is provided."""
+    border = "#" * 72
+    lines = [
+        border,
+        "#  SECURITY WARNING: No key encryption password provided.              #",
+        "#                                                                      #",
+        "#  The private key will be stored unencrypted in Confluent Cloud       #",
+        "#  cluster link configuration and is retrievable by any operator       #",
+        "#  with environment-level access.                                      #",
+        "#                                                                      #",
+        "#  A key encryption password SHALL be used in all production           #",
+        "#  environments. Set KEY_PASSWORD in your environment or provide       #",
+        "#  a password at the prompt.                                           #",
+        border,
+    ]
+    print("\n".join(lines), file=sys.stderr)
+
+
 def sn_bootstrap(host: str, base_port: int, brokers_per_cluster: int = SN_BROKERS_PER_CLUSTER) -> str:
     """Build a bootstrap string for one ServiceNow source cluster."""
     return ",".join(f"{host}:{base_port + i}" for i in range(brokers_per_cluster))
@@ -245,6 +264,8 @@ def main(argv: Optional[List[str]] = None) -> int:
     cfg = load_config(args.config)
     ca_pem, client_cert, client_key = load_pem_files(args.pem_dir)
     key_password = _resolve_key_password()
+    if key_password is None:
+        warn_no_key_password()
 
     if args.copy_config:
         ssl_props = build_ssl_properties(ca_pem, client_cert, client_key,

--- a/sn_confluent/link/tests/test_link.py
+++ b/sn_confluent/link/tests/test_link.py
@@ -537,3 +537,75 @@ def test_resolve_key_password_env_var_skips_prompt(monkeypatch):
     monkeypatch.setenv("KEY_PASSWORD", "env-secret")
     monkeypatch.setattr("getpass.getpass", lambda _prompt: (_ for _ in ()).throw(AssertionError("getpass must not be called when env var is set")))
     assert _resolve_key_password() == "env-secret"
+
+
+# ---------------------------------------------------------------------------
+# warn_no_key_password
+# ---------------------------------------------------------------------------
+
+def test_warn_no_key_password_prints_to_stderr(capsys):
+    from sn_confluent.link.main import warn_no_key_password
+    warn_no_key_password()
+    err = capsys.readouterr().err
+    assert "SECURITY WARNING" in err
+    assert "SHALL" in err
+    assert "production" in err
+
+
+def test_main_warns_when_no_key_password(tmp_path, capsys):
+    from sn_confluent.link.main import main
+    cfg_text = textwrap.dedent("""\
+        [confluent]
+        environment_id   = env-abc123
+        cluster_id       = lkc-abc123
+        link_name        = my-link
+        source_bootstrap = broker.example.com:9093
+    """)
+    (tmp_path / "link.conf").write_text(cfg_text)
+    (tmp_path / "ca.pem").write_bytes(b"CA")
+    (tmp_path / "client-cert.pem").write_bytes(b"CERT")
+    (tmp_path / "client-key.pem").write_bytes(b"KEY")
+
+    with patch("sys.argv", [
+        "create_link.py",
+        "--config", str(tmp_path / "link.conf"),
+        "--pem-dir", str(tmp_path),
+        "--dry-run",
+    ]):
+        with patch("sn_confluent.link.main._resolve_key_password", return_value=None):
+            with patch("sn_confluent.link.main.check_confluent_cli"):
+                with patch("sn_confluent.link.main.check_auth"):
+                    main()
+
+    err = capsys.readouterr().err
+    assert "SECURITY WARNING" in err
+    assert "SHALL" in err
+
+
+def test_main_no_warn_when_key_password_set(tmp_path, capsys):
+    from sn_confluent.link.main import main
+    cfg_text = textwrap.dedent("""\
+        [confluent]
+        environment_id   = env-abc123
+        cluster_id       = lkc-abc123
+        link_name        = my-link
+        source_bootstrap = broker.example.com:9093
+    """)
+    (tmp_path / "link.conf").write_text(cfg_text)
+    (tmp_path / "ca.pem").write_bytes(b"CA")
+    (tmp_path / "client-cert.pem").write_bytes(b"CERT")
+    (tmp_path / "client-key.pem").write_bytes(b"KEY")
+
+    with patch("sys.argv", [
+        "create_link.py",
+        "--config", str(tmp_path / "link.conf"),
+        "--pem-dir", str(tmp_path),
+        "--dry-run",
+    ]):
+        with patch("sn_confluent.link.main._resolve_key_password", return_value="s3cr3t"):
+            with patch("sn_confluent.link.main.check_confluent_cli"):
+                with patch("sn_confluent.link.main.check_auth"):
+                    main()
+
+    err = capsys.readouterr().err
+    assert "SECURITY WARNING" not in err


### PR DESCRIPTION
## Summary
- Adds a `warn_no_key_password()` function that prints a loud `#`-bordered security warning to stderr when no key password is provided
- The private key is stored unencrypted in Confluent Cloud cluster link config (retrievable by any operator with environment access) when `KEY_PASSWORD` is omitted — the warning makes this risk visible with policy language ("SHALL be used in all production environments")
- Warning fires on both the link creation path and `--copy-config`, before any Confluent CLI calls
- Updated link `README.md` to document the production requirement

## Test plan
- [ ] Run `sn-confluent link --dry-run` without setting `KEY_PASSWORD` and skip the prompt — confirm warning block appears on stderr
- [ ] Run with `KEY_PASSWORD=anything` — confirm no warning
- [ ] `pytest sn_confluent/link/tests/test_link.py -v` — all 45 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)