### PR TITLE
docs: sync all READMEs with v0.2.0 code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,10 @@ sn-confluent/
 │   ├── extract/              # subcommand: PEM extraction
 │   ├── link/                 # subcommand: cluster link creation
 │   ├── mirror/               # subcommand: topic mirroring
+│   ├── worker/               # subcommand: Connect worker config
 │   ├── replicate/            # subcommand: Replicator deployment
+│   ├── deploy/               # subcommand: Hermes custom connector (sink/source)
+│   ├── api_key/              # subcommand: Confluent Cloud API key management
 │   └── setup/                # subcommand: end-to-end wizard
 └── README.md
 ```

--- a/README.md
+++ b/README.md
@@ -23,13 +23,17 @@ Installs the `sn-confluent` console entry point.
 
 | Subcommand | Description |
 |---|---|
-| `sn-confluent extract`   | Extract `ca.pem`, `client-cert.pem`, and `client-key.pem` from PKCS12 keystores |
-| `sn-confluent link`      | Create a Confluent Cloud cluster link from a source Kafka cluster using mTLS |
-| `sn-confluent mirror`    | Mirror ServiceNow Kafka topics to Confluent Cloud across both DC cluster links with a checkbox UI |
+| `sn-confluent extract` | Extract `ca.pem`, `client-cert.pem`, and `client-key.pem` from PKCS12 keystores |
+| `sn-confluent link` | Create a Confluent Cloud cluster link from a source Kafka cluster using mTLS |
+| `sn-confluent mirror` | Mirror ServiceNow Kafka topics to Confluent Cloud across both DC cluster links with a checkbox UI |
+| `sn-confluent worker` | Generate Connect worker config and start script for Confluent Replicator |
 | `sn-confluent replicate` | Deploy a Confluent Replicator connector between ServiceNow Hermes and Confluent Cloud (bidirectional, interactive wizard) |
-| `sn-confluent setup`     | Guided end-to-end wizard that orchestrates the four steps above in one run |
+| `sn-confluent deploy sink` | Deploy the Hermes Kafka Connector to Confluent Cloud as a **sink** (CC → Hermes) |
+| `sn-confluent deploy source` | Deploy the Hermes Kafka Connector to Confluent Cloud as a **source** (Hermes → CC) |
+| `sn-confluent api-key` | Create, list, or delete Confluent Cloud Kafka API keys |
+| `sn-confluent setup` | Guided end-to-end wizard that orchestrates the steps above in one run |
 
-Run `sn-confluent <subcommand> --help` for command-specific options. Each subcommand also has its own README at `sn_confluent/<subcommand>/README.md`.
+Run `sn-confluent <subcommand> --help` for command-specific options. Most subcommands have a README at `sn_confluent/<subcommand>/README.md`.
 
 ## Typical workflow
 
@@ -46,6 +50,12 @@ sn-confluent mirror --pem-dir /tmp/pems
 
 # Step 4 — deploy Replicator (alternative to native cluster links)
 sn-confluent replicate --pem-dir /tmp/pems
+
+# Alternatively — deploy via the Hermes custom Kafka Connector
+cp sn_confluent/deploy/deploy.conf.example sn_confluent/deploy/deploy.conf  # fill in your cluster/API details
+sn-confluent deploy sink    # CC → Hermes
+# or
+sn-confluent deploy source  # Hermes → CC
 ```
 
 Or run all four with the guided wizard:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sn-confluent"
-version = "0.1.0"
+version = "0.2.0"
 description = "CLI tools for integrating ServiceNow's Kafka infrastructure with Confluent Cloud."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/sn_confluent/cli.py
+++ b/sn_confluent/cli.py
@@ -17,7 +17,7 @@ SUBCOMMAND_HELP = {
     "mirror": "Mirror ServiceNow Kafka topics to Confluent Cloud",
     "worker": "Generate Connect worker config and start script for Replicator",
     "replicate": "Deploy a Confluent Replicator connector",
-    "deploy": "Deploy the ServiceNow Hermes Kafka Connector to Confluent Cloud",
+    "deploy": "Deploy the ServiceNow Hermes Kafka Connector to Confluent Cloud (sink or source)",
     "api-key": "Create, list, or delete Confluent Cloud Kafka API keys",
     "setup": "Guided end-to-end setup wizard",
 }

--- a/sn_confluent/core/confluent.py
+++ b/sn_confluent/core/confluent.py
@@ -1,0 +1,39 @@
+"""Confluent CLI subprocess helpers shared across subcommands."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from typing import List, Optional
+
+
+def list_cc_topics(environment_id: str, cluster_id: str) -> Optional[List[str]]:
+    """Return sorted CC topic names, or None on failure.
+
+    Callers that need hard-fail behaviour should check for None and sys.exit(1).
+    """
+    result = subprocess.run(
+        [
+            "confluent", "kafka", "topic", "list",
+            "--cluster", cluster_id,
+            "--environment", environment_id,
+            "--output", "json",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(
+            f"Warning: Could not list CC topics: {result.stderr.strip()}",
+            file=sys.stderr,
+        )
+        return None
+    try:
+        topics = json.loads(result.stdout)
+        return sorted(t["name"] for t in topics)
+    except (json.JSONDecodeError, KeyError):
+        return None
+
+
+__all__ = ["list_cc_topics"]

--- a/sn_confluent/core/hermes.py
+++ b/sn_confluent/core/hermes.py
@@ -10,7 +10,10 @@ print a warning if it is not installed.
 
 from __future__ import annotations
 
+import os
+import shutil
 import sys
+import tempfile
 from typing import List, Optional
 
 from sn_confluent.core.pem import SN_SOURCE_CLUSTERS, SN_BROKERS_PER_CLUSTER
@@ -28,31 +31,52 @@ class HermesClient:
         client_cert_pem: bytes,
         client_key_pem: bytes,
         key_password: Optional[str] = None,
+        brokers_per_cluster: int = SN_BROKERS_PER_CLUSTER,
     ) -> None:
         self.instance_name = instance_name
+        self._brokers_per_cluster = brokers_per_cluster
+        # kafka-python 2.x only accepts file paths (ssl_cafile etc.), not in-memory _data variants.
+        self._tmpdir = tempfile.mkdtemp(prefix="hermes_ssl_")
+        ca_path = os.path.join(self._tmpdir, "ca.pem")
+        cert_path = os.path.join(self._tmpdir, "cert.pem")
+        key_path = os.path.join(self._tmpdir, "key.pem")
+        with open(ca_path, "wb") as f:
+            f.write(ca_pem)
+        with open(cert_path, "wb") as f:
+            f.write(client_cert_pem)
+        with open(key_path, "wb") as f:
+            f.write(client_key_pem)
         self._ssl = dict(
             security_protocol="SSL",
-            ssl_cafile_data=ca_pem.decode("utf-8"),
-            ssl_certfile_data=client_cert_pem.decode("utf-8"),
-            ssl_keyfile_data=client_key_pem.decode("utf-8"),
+            ssl_cafile=ca_path,
+            ssl_certfile=cert_path,
+            ssl_keyfile=key_path,
         )
         if key_password:
             self._ssl["ssl_password"] = key_password
 
+    def __del__(self) -> None:
+        shutil.rmtree(getattr(self, "_tmpdir", ""), ignore_errors=True)
+
     def _admin(self, bootstrap: str):
-        from kafka.admin import KafkaAdminClient
+        try:
+            from kafka.admin import KafkaAdminClient
+        except ImportError:
+            raise ImportError("kafka-python is required: pip install kafka-python") from None
         return KafkaAdminClient(bootstrap_servers=bootstrap, **self._ssl)
 
     @property
     def _hostname(self) -> str:
         """Return the broker hostname, appending .service-now.com if not already a FQDN."""
+        if not self.instance_name:
+            raise ValueError("instance_name must not be empty")
         if "." in self.instance_name:
             return self.instance_name
         return f"{self.instance_name}.service-now.com"
 
-    def _bootstrap(self, base_port: int, n: int = SN_BROKERS_PER_CLUSTER) -> str:
+    def _bootstrap(self, base_port: int) -> str:
         return ",".join(
-            f"{self._hostname}:{base_port + i}" for i in range(n)
+            f"{self._hostname}:{base_port + i}" for i in range(self._brokers_per_cluster)
         )
 
     def list_topics(self, base_port: int = _SINK_BASE_PORT) -> Optional[List[str]]:
@@ -62,6 +86,9 @@ class HermesClient:
         try:
             admin = self._admin(bootstrap)
             raw = admin.list_topics()
+        except ImportError as exc:
+            print(f"Warning: {exc}", file=sys.stderr)
+            return None
         except Exception as exc:
             print(
                 f"Warning: Could not connect to Hermes at {bootstrap}: {exc}",
@@ -99,6 +126,9 @@ class HermesClient:
                 )
                 return None
             return sorted(b.port for b in brokers)
+        except ImportError as exc:
+            print(f"Warning: {exc}", file=sys.stderr)
+            return None
         except Exception as exc:
             print(
                 f"Warning: Could not probe Hermes cluster at {bootstrap}: {exc}",
@@ -118,7 +148,7 @@ class HermesClient:
         Returns None on failure — caller should fall back to the default port ranges
         (SN_SOURCE_CLUSTERS / SN_BROKERS_PER_CLUSTER).
         """
-        parts: List[str] = []
+        endpoints: List[str] = []
         for base_port in SN_SOURCE_CLUSTERS:
             ports = self.discover_broker_ports(base_port)
             if ports is None:
@@ -127,11 +157,8 @@ class HermesClient:
                 f"  Source cluster {base_port}: {len(ports)} broker(s), "
                 f"ports {ports[0]}-{ports[-1]}"
             )
-            parts.append(
-                f"{self._hostname}:"
-                + ",".join(str(p) for p in ports)
-            )
-        return ",".join(parts)
+            endpoints.extend(f"{self._hostname}:{p}" for p in ports)
+        return ",".join(endpoints)
 
 
 __all__ = ["HermesClient"]

--- a/sn_confluent/core/hermes.py
+++ b/sn_confluent/core/hermes.py
@@ -1,0 +1,137 @@
+"""Hermes (ServiceNow Kafka) AdminClient wrapper.
+
+Provides KafkaAdminClient-backed helpers for topic listing and broker
+topology discovery. Used by the deploy subcommand for both sink and source
+connector configuration.
+
+kafka-python is an optional runtime dependency — methods return None and
+print a warning if it is not installed.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import List, Optional
+
+from sn_confluent.core.pem import SN_SOURCE_CLUSTERS, SN_BROKERS_PER_CLUSTER
+
+_SINK_BASE_PORT = 4000
+
+
+class HermesClient:
+    """Thin wrapper around kafka-python's KafkaAdminClient for a single Hermes instance."""
+
+    def __init__(
+        self,
+        instance_name: str,
+        ca_pem: bytes,
+        client_cert_pem: bytes,
+        client_key_pem: bytes,
+        key_password: Optional[str] = None,
+    ) -> None:
+        self.instance_name = instance_name
+        self._ssl = dict(
+            security_protocol="SSL",
+            ssl_cafile_data=ca_pem.decode("utf-8"),
+            ssl_certfile_data=client_cert_pem.decode("utf-8"),
+            ssl_keyfile_data=client_key_pem.decode("utf-8"),
+        )
+        if key_password:
+            self._ssl["ssl_password"] = key_password
+
+    def _admin(self, bootstrap: str):
+        from kafka.admin import KafkaAdminClient
+        return KafkaAdminClient(bootstrap_servers=bootstrap, **self._ssl)
+
+    @property
+    def _hostname(self) -> str:
+        """Return the broker hostname, appending .service-now.com if not already a FQDN."""
+        if "." in self.instance_name:
+            return self.instance_name
+        return f"{self.instance_name}.service-now.com"
+
+    def _bootstrap(self, base_port: int, n: int = SN_BROKERS_PER_CLUSTER) -> str:
+        return ",".join(
+            f"{self._hostname}:{base_port + i}" for i in range(n)
+        )
+
+    def list_topics(self, base_port: int = _SINK_BASE_PORT) -> Optional[List[str]]:
+        """Return sorted topic names from the cluster at base_port, or None on failure."""
+        bootstrap = self._bootstrap(base_port)
+        admin = None
+        try:
+            admin = self._admin(bootstrap)
+            raw = admin.list_topics()
+        except Exception as exc:
+            print(
+                f"Warning: Could not connect to Hermes at {bootstrap}: {exc}",
+                file=sys.stderr,
+            )
+            return None
+        finally:
+            if admin is not None:
+                try:
+                    admin.close()
+                except Exception:
+                    pass
+        return sorted(
+            t for t in raw
+            if not t.startswith("__") and not t.startswith("_confluent")
+        )
+
+    def discover_broker_ports(self, base_port: int) -> Optional[List[int]]:
+        """Connect to the cluster at base_port and return actual broker port numbers.
+
+        Uses the Kafka metadata response — one bootstrap connection reveals the
+        full broker list for that cluster.
+        """
+        bootstrap = f"{self._hostname}:{base_port}"
+        admin = None
+        try:
+            admin = self._admin(bootstrap)
+            future = admin._client.cluster.request_update()
+            admin._client.poll(future=future, timeout_ms=10000)
+            brokers = admin._client.cluster.brokers()
+            if not brokers:
+                print(
+                    f"Warning: No brokers returned from {bootstrap}.",
+                    file=sys.stderr,
+                )
+                return None
+            return sorted(b.port for b in brokers)
+        except Exception as exc:
+            print(
+                f"Warning: Could not probe Hermes cluster at {bootstrap}: {exc}",
+                file=sys.stderr,
+            )
+            return None
+        finally:
+            if admin is not None:
+                try:
+                    admin.close()
+                except Exception:
+                    pass
+
+    def source_egress_endpoints(self) -> Optional[str]:
+        """Probe both source peer clusters and return the confluent.custom.connection.endpoints value.
+
+        Returns None on failure — caller should fall back to the default port ranges
+        (SN_SOURCE_CLUSTERS / SN_BROKERS_PER_CLUSTER).
+        """
+        parts: List[str] = []
+        for base_port in SN_SOURCE_CLUSTERS:
+            ports = self.discover_broker_ports(base_port)
+            if ports is None:
+                return None
+            print(
+                f"  Source cluster {base_port}: {len(ports)} broker(s), "
+                f"ports {ports[0]}-{ports[-1]}"
+            )
+            parts.append(
+                f"{self._hostname}:"
+                + ",".join(str(p) for p in ports)
+            )
+        return ",".join(parts)
+
+
+__all__ = ["HermesClient"]

--- a/sn_confluent/core/pem.py
+++ b/sn_confluent/core/pem.py
@@ -32,6 +32,64 @@ def check_confluent_cli() -> None:
         sys.exit(1)
 
 
+def ensure_authenticated(cfg: dict) -> None:
+    """Ensure the Confluent CLI is installed and authenticated.
+
+    Resolution order:
+    1. Cloud API key — if cloud_api_key/cloud_api_secret are present in cfg
+       (or CC_CLOUD_API_KEY/CC_CLOUD_API_SECRET env vars), log in with them
+       non-interactively. Best for automation; tokens never expire.
+    2. Saved credentials — if a prior `confluent login --save` stored a
+       DPAPI-encrypted password, the CLI re-authenticates silently on Windows
+       without a browser prompt. Tried automatically when no API key is set.
+    3. Manual — if neither works, the user must run `confluent login`.
+    """
+    if shutil.which("confluent") is None:
+        print(CONFLUENT_INSTALL)
+        sys.exit(1)
+
+    cloud_key = (
+        os.environ.get("CC_CLOUD_API_KEY", "").strip()
+        or cfg.get("cloud_api_key", "").strip()
+    )
+    cloud_secret = (
+        os.environ.get("CC_CLOUD_API_SECRET", "").strip()
+        or cfg.get("cloud_api_secret", "").strip()
+    )
+
+    if cloud_key and cloud_secret:
+        # Cloud API keys are consumed via env vars — the CLI picks them up
+        # automatically and skips the SSO session requirement entirely.
+        os.environ["CONFLUENT_CLOUD_API_KEY"] = cloud_key
+        os.environ["CONFLUENT_CLOUD_API_SECRET"] = cloud_secret
+        return
+
+    # No API key — check if already authenticated; if not, try to refresh
+    # from the DPAPI-encrypted saved credentials (Windows silent re-auth).
+    probe = subprocess.run(
+        ["confluent", "whoami"],
+        capture_output=True,
+        text=True,
+    )
+    if probe.returncode == 0:
+        return  # already authenticated
+
+    print("Confluent CLI session expired — attempting re-login with saved credentials...")
+    relogin = subprocess.run(
+        ["confluent", "login", "--save"],
+        capture_output=True,
+        text=True,
+    )
+    if relogin.returncode != 0:
+        print(
+            "Error: Confluent CLI is not authenticated and re-login failed.\n"
+            "Run: confluent login --save\n"
+            "Or add cloud_api_key / cloud_api_secret to deploy.conf for non-interactive auth.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
 def check_auth(environment_id: str, cluster_id: str) -> None:
     """Verify Confluent CLI auth by describing the destination cluster."""
     result = subprocess.run(
@@ -78,6 +136,7 @@ __all__ = [
     "SN_BROKERS_PER_CLUSTER",
     "CONFLUENT_INSTALL",
     "check_confluent_cli",
+    "ensure_authenticated",
     "check_auth",
     "load_pem_files",
 ]

--- a/sn_confluent/deploy/README.md
+++ b/sn_confluent/deploy/README.md
@@ -1,0 +1,104 @@
+# deploy
+
+Deploys the ServiceNow Hermes Kafka connector to Confluent Cloud as a fully-managed Custom Connector — either as a **sink** (Confluent Cloud → Hermes, i.e. messages flow from a CC topic into ServiceNow) or a **source** (Hermes → Confluent Cloud, i.e. messages flow from ServiceNow into a CC topic). The tool uploads the connector plugin JAR, registers it as a Custom Connector Plugin, and creates or updates the connector instance on the target cluster.
+
+## Prerequisites
+
+- Python 3.10+
+- Confluent CLI installed (`confluent` on `PATH`)
+- A `deploy.conf` filled in from the example (see below)
+- The connector plugin ZIP built from the sibling `ServiceNow-source-and-sink-connector/` repo (auto-detected by default)
+- A Confluent Cloud API key + secret scoped to the target cluster (`kafka_api_key` / `kafka_api_secret` in config, or `CC_API_KEY` / `CC_API_SECRET` env vars)
+- A Cloud-level API key for the Confluent CLI itself (`cloud_api_key` / `cloud_api_secret`, or `CC_CLOUD_API_KEY` / `CC_CLOUD_API_SECRET` env vars)
+
+## Configuration
+
+Copy and fill in `deploy.conf`:
+
+```bash
+cp deploy.conf.example deploy.conf
+```
+
+```ini
+[confluent]
+environment_id  = env-xxxxx
+cluster_id      = lkc-xxxxx
+
+connector_name  = hermes-sink-prod
+
+# Plugin ID from a prior upload — leave blank to upload on first run.
+# After uploading, paste the returned ccp-xxxxx value here to skip future uploads.
+plugin_id       =
+
+topics          = my-topic
+instance_name   = myinstance
+hermes_topic    = snc.myinstance.sn_streamconnect.my-topic
+
+keystore_path   = /path/to/keystore.p12
+keystore_password = changeit
+truststore_path = /path/to/truststore.p12
+truststore_password = changeit
+
+kafka_api_key   =
+kafka_api_secret =
+
+cloud_api_key   =
+cloud_api_secret =
+
+# Optional
+# cloud       = aws       # aws (default), gcp, azure
+# tasks_max   = 1
+# plugin_file = ../ServiceNow-source-and-sink-connector/target/components/packages/servicenow-hermes-kafka-connector-0.1.0.zip
+# plugin_name = hermes-sink-plugin
+```
+
+## Usage
+
+```bash
+# Deploy a sink connector (CC topic → Hermes)
+sn-confluent deploy sink --config deploy.conf
+
+# Deploy a source connector (Hermes → CC topic)
+sn-confluent deploy source --config deploy.conf
+```
+
+```bash
+# Skip the plugin upload step when the plugin already exists
+sn-confluent deploy sink --plugin-id ccp-xxxxx
+
+# Re-upload a new JAR to an existing plugin
+sn-confluent deploy sink --plugin-id ccp-xxxxx --update-plugin
+
+# Point at a specific connector ZIP
+sn-confluent deploy sink --plugin-file ../ServiceNow-source-and-sink-connector/target/components/packages/servicenow-hermes-kafka-connector-0.1.0.zip
+
+# Dry run — print connector config JSON without creating anything
+sn-confluent deploy sink --dry-run
+
+# Non-interactive (CI/CD) — fail if any required value is missing
+sn-confluent deploy sink --no-wizard
+```
+
+## Options
+
+| Flag | Default | Description |
+|---|---|---|
+| `--config PATH` | `./deploy.conf` | Path to deploy.conf |
+| `--plugin-id ID` | — | Existing Custom Connector Plugin ID — skip the upload step |
+| `--update-plugin` | off | Update the plugin at `--plugin-id` with a new JAR instead of creating a new plugin |
+| `--plugin-file PATH` | auto-detected in sibling repo | Connector ZIP path |
+| `--cloud {aws,gcp,azure}` | `aws` | Cloud provider for plugin upload |
+| `--timeout SECONDS` | `900` | Connector status poll timeout |
+| `--pem-dir PATH` | — | Directory containing `ca.pem`, `client-cert.pem`, `client-key.pem` for Hermes topic listing |
+| `--dry-run` | off | Print connector config JSON without creating anything |
+| `--no-wizard` | off | Non-interactive: fail immediately if any required value is missing from config |
+
+## Wizard vs. non-interactive
+
+By default an interactive wizard prompts for any required values missing from the config file. Pass `--no-wizard` to disable prompts and fail immediately if the config is incomplete — useful in CI/CD pipelines.
+
+## Tests
+
+```bash
+pytest sn_confluent/deploy/tests/
+```

--- a/sn_confluent/deploy/deploy.conf.example
+++ b/sn_confluent/deploy/deploy.conf.example
@@ -29,6 +29,13 @@ truststore_password = changeit
 kafka_api_key =
 kafka_api_secret =
 
+# Cloud-level API key for the Confluent CLI itself (separate from the Kafka cluster key above).
+# Create one at: Confluent Cloud → Hamburger menu → Cloud API keys → + Add API key → Granular access
+# When set, the deploy tool auto-logs in non-interactively — no `confluent login` required.
+# Alternatively set CC_CLOUD_API_KEY / CC_CLOUD_API_SECRET env vars.
+cloud_api_key =
+cloud_api_secret =
+
 # ---- Optional ----
 
 # Cloud provider for plugin upload: aws (default), gcp, azure

--- a/sn_confluent/deploy/main.py
+++ b/sn_confluent/deploy/main.py
@@ -347,9 +347,9 @@ def build_sink_config(
         "hermes.ssl.keystore.password": keystore_password,
         "hermes.ssl.truststore.b64": truststore_b64,
         "hermes.ssl.truststore.password": truststore_password,
-        "confluent.custom.connection.endpoints": (
-            f"{instance_name}.service-now.com:"
-            + ",".join(str(p) for p in range(4000, 4008))
+        "confluent.custom.connection.endpoints": ",".join(
+            f"{instance_name if '.' in instance_name else instance_name + '.service-now.com'}:{p}"
+            for p in range(4000, 4008)
         ),
     }
 

--- a/sn_confluent/deploy/main.py
+++ b/sn_confluent/deploy/main.py
@@ -1,7 +1,8 @@
 # Deploy the ServiceNow Hermes Kafka Connector as a Confluent Cloud Custom Connector.
 #
-# Usage: sn-confluent deploy [--config PATH] [--plugin-id ID | --plugin-file PATH]
-#        [--cloud {aws,gcp,azure}] [--no-wizard] [--dry-run] [--timeout SECONDS]
+# Usage: sn-confluent deploy sink   [--config PATH] [--plugin-id ID | --plugin-file PATH]
+#                                   [--cloud {aws,gcp,azure}] [--no-wizard] [--dry-run]
+#        sn-confluent deploy source [same flags]
 
 import argparse
 import base64
@@ -19,8 +20,9 @@ from typing import List, Optional, Tuple
 from sn_confluent.core.pem import check_confluent_cli, ensure_authenticated
 from sn_confluent.core.config import load_config as _core_load_config
 
-CONNECTOR_CLASS = "com.servicenow.kafka.connect.hermes.HermesSinkConnector"
-CONNECTOR_TYPE = "sink"
+SINK_CONNECTOR_CLASS = "com.servicenow.kafka.connect.hermes.HermesSinkConnector"
+SOURCE_CONNECTOR_CLASS = "com.servicenow.kafka.connect.hermes.HermesSourceConnector"
+
 SENSITIVE_PROPERTIES_CSV = (
     "hermes.ssl.keystore.b64,"
     "hermes.ssl.keystore.password,"
@@ -44,13 +46,22 @@ _SENSITIVE_CONFIG_KEYS = frozenset({
     "hermes.ssl.truststore.password",
 })
 
-EGRESS_NOTE = """\
+SINK_EGRESS_NOTE = """\
 Action required — configure Confluent Cloud egress endpoint:
-  {instance}.service-now.com:4000-4050
+  {instance}.service-now.com:4000-4007
 
 In the Confluent Cloud Console:
   Connectors > {connector} > Networking > Add egress endpoint
 """
+
+SOURCE_EGRESS_NOTE = """\
+Action required — configure Confluent Cloud egress endpoints for two Hermes clusters:
+  {instance}.service-now.com:4100-4107
+  {instance}.service-now.com:4200-4207
+
+In the Confluent Cloud Console:
+  Connectors > {connector} > Networking > Add egress endpoint
+"""  # TODO: verify port ranges per cluster
 
 
 def load_config(path: str) -> dict:
@@ -142,9 +153,9 @@ def resolve_api_credentials(
 ) -> tuple:
     """Resolve Kafka API key/secret for the connector.
 
-    Order: CC_API_KEY/CC_API_SECRET env vars → config kafka_api_key/kafka_api_secret
-    → auto-generate via confluent api-key create (when environment_id + cluster_id are
-    available) → interactive prompt.
+    Order: CC_API_KEY/CC_API_SECRET env vars -> config kafka_api_key/kafka_api_secret
+    -> auto-generate via confluent api-key create (when environment_id + cluster_id are
+    available) -> interactive prompt.
     """
     api_key = os.environ.get("CC_API_KEY", "").strip() or cfg.get("kafka_api_key", "").strip()
     api_secret = os.environ.get("CC_API_SECRET", "").strip() or cfg.get("kafka_api_secret", "").strip()
@@ -302,15 +313,21 @@ def _resolve_hermes_pem(
         return None
 
 
-def upload_plugin(plugin_file: str, plugin_name: str, cloud: str) -> str:
+def upload_plugin(
+    plugin_file: str,
+    plugin_name: str,
+    cloud: str,
+    connector_type: str,
+    connector_class: str,
+) -> str:
     """Upload the connector ZIP as a Confluent Cloud custom plugin. Returns plugin ID."""
     print(f"Uploading plugin from {plugin_file}...")
     result = subprocess.run(
         [
             "confluent", "connect", "custom-plugin", "create", plugin_name,
             "--plugin-file", plugin_file,
-            "--connector-type", CONNECTOR_TYPE,
-            "--connector-class", CONNECTOR_CLASS,
+            "--connector-type", connector_type,
+            "--connector-class", connector_class,
             "--sensitive-properties", SENSITIVE_PROPERTIES_CSV,
             "--cloud", cloud,
             "--output", "json",
@@ -350,7 +367,7 @@ def update_plugin(plugin_id: str, plugin_file: str) -> None:
     print(f"Plugin {plugin_id} updated.")
 
 
-def build_connector_config(
+def build_sink_config(
     plugin_id: str,
     connector_name: str,
     topics: str,
@@ -366,7 +383,7 @@ def build_connector_config(
 ) -> dict:
     return {
         "name": connector_name,
-        "connector.class": CONNECTOR_CLASS,
+        "connector.class": SINK_CONNECTOR_CLASS,
         "confluent.custom.plugin.id": plugin_id,
         "confluent.connector.type": "CUSTOM",
         "tasks.max": str(tasks_max),
@@ -385,6 +402,50 @@ def build_connector_config(
         "confluent.custom.connection.endpoints": (
             f"{instance_name}.service-now.com:"
             + ",".join(str(p) for p in range(4000, 4008))
+        ),
+    }
+
+
+def build_source_config(
+    plugin_id: str,
+    connector_name: str,
+    destination_topic: str,
+    api_key: str,
+    api_secret: str,
+    instance_name: str,
+    hermes_source_topic: str,
+    keystore_b64: str,
+    keystore_password: str,
+    truststore_b64: str,
+    truststore_password: str,
+    tasks_max: int = 1,
+    consumer_group_id: str = "hermes-connect-source",
+) -> dict:
+    return {
+        "name": connector_name,
+        "connector.class": SOURCE_CONNECTOR_CLASS,
+        "confluent.custom.plugin.id": plugin_id,
+        "confluent.connector.type": "CUSTOM",
+        "tasks.max": str(tasks_max),
+        "key.converter": "org.apache.kafka.connect.converters.ByteArrayConverter",
+        "value.converter": "org.apache.kafka.connect.converters.ByteArrayConverter",
+        "kafka.auth.mode": "KAFKA_API_KEY",
+        "kafka.api.key": api_key,
+        "kafka.api.secret": api_secret,
+        "hermes.instance.name": instance_name,
+        "hermes.source.topic": hermes_source_topic,
+        "hermes.consumer.group.id": consumer_group_id,
+        "hermes.destination.topic": destination_topic,
+        "hermes.ssl.keystore.b64": keystore_b64,
+        "hermes.ssl.keystore.password": keystore_password,
+        "hermes.ssl.truststore.b64": truststore_b64,
+        "hermes.ssl.truststore.password": truststore_password,
+        # Two Hermes peer clusters; TODO: verify port ranges and count per cluster
+        "confluent.custom.connection.endpoints": (
+            f"{instance_name}.service-now.com:"
+            + ",".join(str(p) for p in range(4100, 4108))
+            + f",{instance_name}.service-now.com:"
+            + ",".join(str(p) for p in range(4200, 4208))
         ),
     }
 
@@ -487,97 +548,9 @@ def _mask(config: dict) -> dict:
     return {k: "[hidden]" if k in _SENSITIVE_CONFIG_KEYS else v for k, v in config.items()}
 
 
-def _run_wizard(cfg: dict, missing: set) -> dict:
-    """Prompt for any values absent from config. Returns the updated cfg dict."""
-    try:
-        import questionary
-    except ImportError:
-        print(
-            "Error: questionary is required for interactive mode.\n"
-            "Install it: pip install questionary\n"
-            "Or use --no-wizard with a fully populated deploy.conf.",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-
-    print("\n--- Hermes Connector Deployment Wizard ---\n")
-
-    # Collect instance name and keystores first — needed for Hermes topic discovery.
-    if "instance_name" in missing:
-        cfg["instance_name"] = questionary.text(
-            "ServiceNow instance name (bare, e.g. myinstance):"
-        ).ask()
-
-    if "keystore" in missing:
-        source = questionary.select(
-            "Provide keystore as:",
-            choices=["File path (encode automatically)", "Base64 string (paste)"],
-        ).ask()
-        if source and "File path" in source:
-            cfg["keystore_path"] = questionary.text("Path to keystore.p12:").ask()
-        else:
-            cfg["keystore_b64"] = questionary.password("Base64-encoded keystore.p12:").ask()
-
-    if "keystore_password" in missing:
-        cfg["keystore_password"] = questionary.password("Keystore password:").ask()
-
-    if "truststore" in missing:
-        source = questionary.select(
-            "Provide truststore as:",
-            choices=["File path (encode automatically)", "Base64 string (paste)"],
-        ).ask()
-        if source and "File path" in source:
-            cfg["truststore_path"] = questionary.text("Path to truststore.p12:").ask()
-        else:
-            cfg["truststore_b64"] = questionary.password("Base64-encoded truststore.p12:").ask()
-
-    if "truststore_password" in missing:
-        cfg["truststore_password"] = questionary.password("Truststore password:").ask()
-
-    # CC source topic picker
-    if "topics" in missing:
-        print("Fetching topics from Confluent Cloud...")
-        cc_topics = list_cc_topics(cfg["environment_id"], cfg["cluster_id"])
-        if cc_topics:
-            selected = questionary.checkbox(
-                "Select Confluent Cloud topic(s) to read from:",
-                choices=cc_topics,
-            ).ask()
-            cfg["topics"] = ",".join(selected) if selected else ""
-        else:
-            cfg["topics"] = questionary.text(
-                "Confluent Cloud topic(s) to read from (comma-separated):"
-            ).ask()
-
-    # Hermes destination topic picker
-    if "hermes_topic" in missing:
-        instance_name = cfg.get("instance_name", "")
-        hermes_pem = _resolve_hermes_pem(cfg, cfg.get("_pem_dir"))
-        if hermes_pem and instance_name:
-            print(f"Fetching topics from Hermes ({instance_name}.service-now.com)...")
-            hermes_topics = list_hermes_topics(instance_name, *hermes_pem)
-        else:
-            hermes_topics = None
-
-        if hermes_topics:
-            selected = questionary.select(
-                "Select Hermes destination topic:",
-                choices=hermes_topics,
-            ).ask()
-            cfg["hermes_topic"] = selected or ""
-        else:
-            default = f"snc.{instance_name or 'myinstance'}.sn_streamconnect.my-topic"
-            cfg["hermes_topic"] = questionary.text(
-                "Hermes topic name:", default=default,
-            ).ask()
-
-    return cfg
-
-
-def main(argv: Optional[List[str]] = None) -> int:
-    parser = argparse.ArgumentParser(
-        description="Deploy the ServiceNow Hermes Kafka Connector to Confluent Cloud."
-    )
+def _build_arg_parser(description: str) -> argparse.ArgumentParser:
+    """Shared argument parser for sink and source subcommands."""
+    parser = argparse.ArgumentParser(description=description)
     parser.add_argument(
         "--config", default="deploy.conf",
         help="Path to deploy.conf (default: ./deploy.conf)",
@@ -613,6 +586,188 @@ def main(argv: Optional[List[str]] = None) -> int:
     parser.add_argument(
         "--no-wizard", action="store_true",
         help="Non-interactive: fail if any required value is missing from config",
+    )
+    return parser
+
+
+def _run_sink_wizard(cfg: dict, missing: set) -> dict:
+    """Prompt for any values absent from sink config. Returns the updated cfg dict."""
+    try:
+        import questionary
+    except ImportError:
+        print(
+            "Error: questionary is required for interactive mode.\n"
+            "Install it: pip install questionary\n"
+            "Or use --no-wizard with a fully populated deploy.conf.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    print("\n--- Hermes Sink Connector Deployment Wizard ---\n")
+
+    # Collect instance name and keystores first — needed for Hermes topic discovery.
+    if "instance_name" in missing:
+        cfg["instance_name"] = questionary.text(
+            "ServiceNow instance name (bare, e.g. myinstance):"
+        ).ask()
+
+    if "keystore" in missing:
+        source = questionary.select(
+            "Provide keystore as:",
+            choices=["File path (encode automatically)", "Base64 string (paste)"],
+        ).ask()
+        if source and "File path" in source:
+            cfg["keystore_path"] = questionary.text("Path to keystore.p12:").ask()
+        else:
+            cfg["keystore_b64"] = questionary.password("Base64-encoded keystore.p12:").ask()
+
+    if "keystore_password" in missing:
+        cfg["keystore_password"] = questionary.password("Keystore password:").ask()
+
+    if "truststore" in missing:
+        source = questionary.select(
+            "Provide truststore as:",
+            choices=["File path (encode automatically)", "Base64 string (paste)"],
+        ).ask()
+        if source and "File path" in source:
+            cfg["truststore_path"] = questionary.text("Path to truststore.p12:").ask()
+        else:
+            cfg["truststore_b64"] = questionary.password("Base64-encoded truststore.p12:").ask()
+
+    if "truststore_password" in missing:
+        cfg["truststore_password"] = questionary.password("Truststore password:").ask()
+
+    # CC topic picker — sink reads FROM Confluent Cloud
+    if "topics" in missing:
+        print("Fetching topics from Confluent Cloud...")
+        cc_topics = list_cc_topics(cfg["environment_id"], cfg["cluster_id"])
+        if cc_topics:
+            selected = questionary.checkbox(
+                "Select Confluent Cloud topic(s) to read from:",
+                choices=cc_topics,
+            ).ask()
+            cfg["topics"] = ",".join(selected) if selected else ""
+        else:
+            cfg["topics"] = questionary.text(
+                "Confluent Cloud topic(s) to read from (comma-separated):"
+            ).ask()
+
+    # Hermes destination topic picker — sink writes TO Hermes
+    if "hermes_topic" in missing:
+        instance_name = cfg.get("instance_name", "")
+        hermes_pem = _resolve_hermes_pem(cfg, cfg.get("_pem_dir"))
+        if hermes_pem and instance_name:
+            print(f"Fetching topics from Hermes ({instance_name}.service-now.com)...")
+            hermes_topics = list_hermes_topics(instance_name, *hermes_pem)
+        else:
+            hermes_topics = None
+
+        if hermes_topics:
+            selected = questionary.select(
+                "Select Hermes destination topic:",
+                choices=hermes_topics,
+            ).ask()
+            cfg["hermes_topic"] = selected or ""
+        else:
+            default = f"snc.{instance_name or 'myinstance'}.sn_streamconnect.my-topic"
+            cfg["hermes_topic"] = questionary.text(
+                "Hermes topic to write to:", default=default,
+            ).ask()
+
+    return cfg
+
+
+def _run_source_wizard(cfg: dict, missing: set) -> dict:
+    """Prompt for any values absent from source config. Returns the updated cfg dict."""
+    try:
+        import questionary
+    except ImportError:
+        print(
+            "Error: questionary is required for interactive mode.\n"
+            "Install it: pip install questionary\n"
+            "Or use --no-wizard with a fully populated deploy.conf.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    print("\n--- Hermes Source Connector Deployment Wizard ---\n")
+
+    # Collect instance name and keystores first — needed for Hermes topic discovery.
+    if "instance_name" in missing:
+        cfg["instance_name"] = questionary.text(
+            "ServiceNow instance name (bare, e.g. myinstance):"
+        ).ask()
+
+    if "keystore" in missing:
+        source = questionary.select(
+            "Provide keystore as:",
+            choices=["File path (encode automatically)", "Base64 string (paste)"],
+        ).ask()
+        if source and "File path" in source:
+            cfg["keystore_path"] = questionary.text("Path to keystore.p12:").ask()
+        else:
+            cfg["keystore_b64"] = questionary.password("Base64-encoded keystore.p12:").ask()
+
+    if "keystore_password" in missing:
+        cfg["keystore_password"] = questionary.password("Keystore password:").ask()
+
+    if "truststore" in missing:
+        source = questionary.select(
+            "Provide truststore as:",
+            choices=["File path (encode automatically)", "Base64 string (paste)"],
+        ).ask()
+        if source and "File path" in source:
+            cfg["truststore_path"] = questionary.text("Path to truststore.p12:").ask()
+        else:
+            cfg["truststore_b64"] = questionary.password("Base64-encoded truststore.p12:").ask()
+
+    if "truststore_password" in missing:
+        cfg["truststore_password"] = questionary.password("Truststore password:").ask()
+
+    # Hermes source topic picker — source reads FROM Hermes
+    if "hermes_topic" in missing:
+        instance_name = cfg.get("instance_name", "")
+        hermes_pem = _resolve_hermes_pem(cfg, cfg.get("_pem_dir"))
+        if hermes_pem and instance_name:
+            print(f"Fetching topics from Hermes ({instance_name}.service-now.com)...")
+            hermes_topics = list_hermes_topics(instance_name, *hermes_pem)
+        else:
+            hermes_topics = None
+
+        if hermes_topics:
+            selected = questionary.select(
+                "Select Hermes topic to read from:",
+                choices=hermes_topics,
+            ).ask()
+            cfg["hermes_topic"] = selected or ""
+        else:
+            default = f"snc.{instance_name or 'myinstance'}.sn_streamconnect.my-topic"
+            cfg["hermes_topic"] = questionary.text(
+                "Hermes topic to read from:", default=default,
+            ).ask()
+
+    # CC topic picker — source writes TO Confluent Cloud
+    if "topics" in missing:
+        print("Fetching topics from Confluent Cloud...")
+        cc_topics = list_cc_topics(cfg["environment_id"], cfg["cluster_id"])
+        if cc_topics:
+            selected = questionary.select(
+                "Select Confluent Cloud topic to write to:",
+                choices=cc_topics,
+            ).ask()
+            cfg["topics"] = selected or ""
+        else:
+            cfg["topics"] = questionary.text(
+                "Confluent Cloud topic to write to:"
+            ).ask()
+
+    return cfg
+
+
+def _sink_main(argv: Optional[List[str]] = None) -> int:
+    parser = _build_arg_parser(
+        "Deploy the ServiceNow HermesSinkConnector to Confluent Cloud."
+        " Data flows: Confluent Cloud topics -> ServiceNow Hermes."
     )
     args = parser.parse_args(argv)
 
@@ -666,7 +821,11 @@ def main(argv: Optional[List[str]] = None) -> int:
             plugin_id = "ccp-dryrun"
         else:
             plugin_name = cfg.get("plugin_name", "").strip() or f"{connector_name}-plugin"
-            plugin_id = upload_plugin(plugin_file, plugin_name, cloud)
+            plugin_id = upload_plugin(
+                plugin_file, plugin_name, cloud,
+                connector_type="sink",
+                connector_class=SINK_CONNECTOR_CLASS,
+            )
 
     # 4. Resolve Confluent Cloud API credentials (used in kafka.api.key/secret)
     api_key, api_secret = resolve_api_credentials(cfg, environment_id, cluster_id)
@@ -685,8 +844,6 @@ def main(argv: Optional[List[str]] = None) -> int:
     hermes_topic = cfg.get("hermes_topic", "").strip()
 
     # 6. Identify missing values.
-    # keystore/truststore are only required for the live connector config, not for topic listing
-    # (pem_dir covers listing). Mark them missing only when they'll actually be needed.
     missing = set()
     if not topics:
         missing.add("topics")
@@ -708,7 +865,7 @@ def main(argv: Optional[List[str]] = None) -> int:
             for key in sorted(missing):
                 print(f"Error: Missing required value: {key}", file=sys.stderr)
             sys.exit(1)
-        cfg = _run_wizard(cfg, missing)
+        cfg = _run_sink_wizard(cfg, missing)
         keystore_b64 = resolve_keystore(cfg, "keystore_b64", "keystore_path")
         truststore_b64 = resolve_keystore(cfg, "truststore_b64", "truststore_path")
         keystore_password = cfg.get("keystore_password", "").strip()
@@ -724,14 +881,14 @@ def main(argv: Optional[List[str]] = None) -> int:
             print("Error: hermes_topic is required.", file=sys.stderr)
             sys.exit(1)
 
-    # 7. Validate keystores (decode PKCS12, print cert details, fail early on wrong password)
+    # 7. Validate keystores
     if keystore_b64 and truststore_b64:
         print("Validating keystores...")
         if not validate_keystores(keystore_b64, keystore_password, truststore_b64, truststore_password):
             sys.exit(1)
 
     # 8. Build connector config
-    connector_cfg = build_connector_config(
+    connector_cfg = build_sink_config(
         plugin_id=plugin_id,
         connector_name=connector_name,
         topics=topics,
@@ -754,7 +911,7 @@ def main(argv: Optional[List[str]] = None) -> int:
             f"\nWould run: confluent connect cluster create --config-file <config.json>"
             f" --environment {environment_id} --cluster {cluster_id}"
         )
-        print(EGRESS_NOTE.format(instance=instance_name or "<instance>", connector=connector_name))
+        print(SINK_EGRESS_NOTE.format(instance=instance_name or "<instance>", connector=connector_name))
         return 0
 
     # 10. Wizard confirmation
@@ -778,10 +935,220 @@ def main(argv: Optional[List[str]] = None) -> int:
     poll_connector(environment_id, cluster_id, connector_id, timeout=args.timeout)
     print(f"Connector '{connector_id}' is RUNNING.")
 
-    # 13. Remind about egress endpoints (can't be automated via CLI)
-    print(EGRESS_NOTE.format(instance=instance_name, connector=connector_name))
+    # 13. Remind about egress endpoints
+    print(SINK_EGRESS_NOTE.format(instance=instance_name, connector=connector_name))
 
     return 0
+
+
+def _source_main(argv: Optional[List[str]] = None) -> int:
+    parser = _build_arg_parser(
+        "Deploy the ServiceNow HermesSourceConnector to Confluent Cloud."
+        " Data flows: ServiceNow Hermes -> Confluent Cloud topics."
+    )
+    args = parser.parse_args(argv)
+
+    # 1. Load config
+    cfg = load_config(args.config)
+
+    # 2. Check confluent CLI is on PATH and authenticated
+    ensure_authenticated(cfg)
+
+    environment_id = cfg["environment_id"]
+    cluster_id = cfg["cluster_id"]
+    connector_name = cfg["connector_name"]
+    cloud = args.cloud or cfg.get("cloud", "aws").strip() or "aws"
+    tasks_max = int(cfg.get("tasks_max", "1") or "1")
+
+    # 3. Resolve plugin ID (upload if not already known)
+    plugin_id = args.plugin_id or cfg.get("plugin_id", "").strip()
+
+    if args.update_plugin:
+        if not plugin_id:
+            print("Error: --update-plugin requires --plugin-id or plugin_id in deploy.conf.", file=sys.stderr)
+            sys.exit(1)
+        plugin_file = args.plugin_file or find_plugin_file(cfg.get("plugin_file", "").strip() or None)
+        if not plugin_file:
+            print(
+                "Error: Connector ZIP not found.\n"
+                "Build it first:\n"
+                "  cd ../ServiceNow-source-and-sink-connector && mvn package -DskipTests\n"
+                "Or pass --plugin-file <path>.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        if not args.dry_run:
+            update_plugin(plugin_id, plugin_file)
+        else:
+            print(f"[dry-run] Would update plugin {plugin_id} from: {os.path.abspath(plugin_file)}")
+        return 0
+    elif not plugin_id:
+        plugin_file = args.plugin_file or find_plugin_file(cfg.get("plugin_file", "").strip() or None)
+        if not plugin_file:
+            print(
+                "Error: Connector ZIP not found.\n"
+                "Build it first:\n"
+                "  cd ../ServiceNow-source-and-sink-connector && mvn package -DskipTests\n"
+                "Or pass --plugin-file <path> or set plugin_id in deploy.conf to skip upload.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        if args.dry_run:
+            print(f"[dry-run] Would upload plugin from: {os.path.abspath(plugin_file)}")
+            plugin_id = "ccp-dryrun"
+        else:
+            plugin_name = cfg.get("plugin_name", "").strip() or f"{connector_name}-plugin"
+            plugin_id = upload_plugin(
+                plugin_file, plugin_name, cloud,
+                connector_type="source",
+                connector_class=SOURCE_CONNECTOR_CLASS,
+            )
+
+    # 4. Resolve Confluent Cloud API credentials
+    api_key, api_secret = resolve_api_credentials(cfg, environment_id, cluster_id)
+
+    # 5. Resolve keystore/truststore as base64
+    pem_dir = args.pem_dir or cfg.get("pem_dir", "").strip() or None
+    cfg["_pem_dir"] = pem_dir
+
+    keystore_b64 = resolve_keystore(cfg, "keystore_b64", "keystore_path")
+    truststore_b64 = resolve_keystore(cfg, "truststore_b64", "truststore_path")
+    keystore_password = cfg.get("keystore_password", "").strip()
+    truststore_password = cfg.get("truststore_password", "").strip()
+
+    destination_topic = cfg.get("topics", "").strip()
+    instance_name = cfg.get("instance_name", "").strip()
+    hermes_source_topic = cfg.get("hermes_topic", "").strip()
+    consumer_group_id = cfg.get("consumer_group_id", "hermes-connect-source").strip() or "hermes-connect-source"
+
+    # 6. Identify missing values.
+    missing = set()
+    if not destination_topic:
+        missing.add("topics")
+    if not instance_name:
+        missing.add("instance_name")
+    if not hermes_source_topic:
+        missing.add("hermes_topic")
+    if not keystore_b64:
+        missing.add("keystore")
+    if not keystore_password:
+        missing.add("keystore_password")
+    if not truststore_b64:
+        missing.add("truststore")
+    if not truststore_password:
+        missing.add("truststore_password")
+
+    if missing:
+        if args.no_wizard:
+            for key in sorted(missing):
+                print(f"Error: Missing required value: {key}", file=sys.stderr)
+            sys.exit(1)
+        cfg = _run_source_wizard(cfg, missing)
+        keystore_b64 = resolve_keystore(cfg, "keystore_b64", "keystore_path")
+        truststore_b64 = resolve_keystore(cfg, "truststore_b64", "truststore_path")
+        keystore_password = cfg.get("keystore_password", "").strip()
+        truststore_password = cfg.get("truststore_password", "").strip()
+        destination_topic = cfg.get("topics", "").strip()
+        instance_name = cfg.get("instance_name", "").strip()
+        hermes_source_topic = cfg.get("hermes_topic", "").strip()
+
+        if not destination_topic:
+            print("Error: A destination Confluent Cloud topic is required.", file=sys.stderr)
+            sys.exit(1)
+        if not hermes_source_topic:
+            print("Error: hermes_topic is required.", file=sys.stderr)
+            sys.exit(1)
+
+    # 7. Validate keystores
+    if keystore_b64 and truststore_b64:
+        print("Validating keystores...")
+        if not validate_keystores(keystore_b64, keystore_password, truststore_b64, truststore_password):
+            sys.exit(1)
+
+    # 8. Build connector config
+    connector_cfg = build_source_config(
+        plugin_id=plugin_id,
+        connector_name=connector_name,
+        destination_topic=destination_topic,
+        api_key=api_key,
+        api_secret=api_secret,
+        instance_name=instance_name,
+        hermes_source_topic=hermes_source_topic,
+        keystore_b64=keystore_b64,
+        keystore_password=keystore_password,
+        truststore_b64=truststore_b64,
+        truststore_password=truststore_password,
+        tasks_max=tasks_max,
+        consumer_group_id=consumer_group_id,
+    )
+
+    # 9. Dry-run: show masked config and exit
+    if args.dry_run:
+        print("--- Connector config (dry-run) ---")
+        print(json.dumps(_mask(connector_cfg), indent=2))
+        print(
+            f"\nWould run: confluent connect cluster create --config-file <config.json>"
+            f" --environment {environment_id} --cluster {cluster_id}"
+        )
+        print(SOURCE_EGRESS_NOTE.format(instance=instance_name or "<instance>", connector=connector_name))
+        return 0
+
+    # 10. Wizard confirmation
+    if not args.no_wizard:
+        try:
+            import questionary
+            print("\n--- Connector config preview ---")
+            print(json.dumps(_mask(connector_cfg), indent=2))
+            if not questionary.confirm("Create connector?", default=False).ask():
+                print("Aborted.")
+                return 0
+        except ImportError:
+            pass
+
+    # 11. Create connector
+    print(f"Creating connector '{connector_name}'...")
+    connector_id = create_connector(environment_id, cluster_id, connector_cfg)
+    print(f"Connector created: {connector_id}")
+
+    # 12. Poll until RUNNING
+    poll_connector(environment_id, cluster_id, connector_id, timeout=args.timeout)
+    print(f"Connector '{connector_id}' is RUNNING.")
+
+    # 13. Remind about egress endpoints
+    print(SOURCE_EGRESS_NOTE.format(instance=instance_name, connector=connector_name))
+
+    return 0
+
+
+def _print_deploy_help() -> None:
+    print("usage: sn-confluent deploy <subcommand> [<args>]")
+    print()
+    print("Deploy the ServiceNow Hermes Kafka Connector to Confluent Cloud.")
+    print()
+    print("Subcommands:")
+    print("  sink    Deploy HermesSinkConnector   (Confluent Cloud topics -> ServiceNow Hermes)")
+    print("  source  Deploy HermesSourceConnector (ServiceNow Hermes -> Confluent Cloud topics)")
+    print()
+    print("Run 'sn-confluent deploy <subcommand> --help' for subcommand-specific options.")
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    if argv is None:
+        argv = sys.argv[1:]
+    if argv and argv[0] in ("-h", "--help"):
+        _print_deploy_help()
+        return 0
+    if not argv:
+        _print_deploy_help()
+        return 2
+    sub, rest = argv[0], argv[1:]
+    if sub == "sink":
+        return _sink_main(rest)
+    elif sub == "source":
+        return _source_main(rest)
+    print(f"sn-confluent deploy: unknown subcommand '{sub}'", file=sys.stderr)
+    _print_deploy_help()
+    return 2
 
 
 if __name__ == "__main__":

--- a/sn_confluent/deploy/main.py
+++ b/sn_confluent/deploy/main.py
@@ -63,12 +63,12 @@ In the Confluent Cloud Console:
 
 SOURCE_EGRESS_NOTE = """\
 Action required — configure Confluent Cloud egress endpoints for two Hermes clusters:
-  {instance}.service-now.com:4100-4107
-  {instance}.service-now.com:4200-4207
+  {instance}.service-now.com:4100-4103
+  {instance}.service-now.com:4200-4203
 
 In the Confluent Cloud Console:
   Connectors > {connector} > Networking > Add egress endpoint
-"""  # TODO: verify port ranges per cluster
+"""
 
 
 def load_config(path: str) -> dict:
@@ -390,9 +390,9 @@ def build_source_config(
         "hermes.ssl.truststore.b64": truststore_b64,
         "hermes.ssl.truststore.password": truststore_password,
         "confluent.custom.connection.endpoints": endpoints or ",".join(
-            f"{instance_name}.service-now.com:"
-            + ",".join(str(base + i) for i in range(SN_BROKERS_PER_CLUSTER))
+            f"{instance_name if '.' in instance_name else instance_name + '.service-now.com'}:{base + i}"
             for base in SN_SOURCE_CLUSTERS
+            for i in range(SN_BROKERS_PER_CLUSTER)
         ),
     }
 
@@ -671,13 +671,15 @@ def _run_source_wizard(cfg: dict, missing: set) -> dict:
     if "truststore_password" in missing:
         cfg["truststore_password"] = questionary.password("Truststore password:").ask()
 
-    # Hermes source topic picker — source reads FROM Hermes
+    # Hermes source topic picker — source reads FROM Hermes (source-peer clusters at 4100+)
     if "hermes_topic" in missing:
         instance_name = cfg.get("instance_name", "")
         hermes_pem = _resolve_hermes_pem(cfg, cfg.get("_pem_dir"))
         if hermes_pem and instance_name:
             print(f"Fetching topics from Hermes ({instance_name}.service-now.com)...")
-            hermes_topics = HermesClient(instance_name, *hermes_pem).list_topics()
+            hermes_topics = HermesClient(instance_name, *hermes_pem).list_topics(
+                base_port=SN_SOURCE_CLUSTERS[0]
+            )
         else:
             hermes_topics = None
 
@@ -728,7 +730,7 @@ def _sink_main(argv: Optional[List[str]] = None) -> int:
     cluster_id = cfg["cluster_id"]
     connector_name = cfg["connector_name"]
     cloud = args.cloud or cfg.get("cloud", "aws").strip() or "aws"
-    tasks_max = int(cfg.get("tasks_max", "1") or "1")
+    tasks_max = max(1, int(cfg.get("tasks_max", "1") or "1"))
 
     # 3. Resolve plugin ID (upload if not already known)
     plugin_id = args.plugin_id or cfg.get("plugin_id", "").strip()
@@ -905,7 +907,7 @@ def _source_main(argv: Optional[List[str]] = None) -> int:
     cluster_id = cfg["cluster_id"]
     connector_name = cfg["connector_name"]
     cloud = args.cloud or cfg.get("cloud", "aws").strip() or "aws"
-    tasks_max = int(cfg.get("tasks_max", "1") or "1")
+    tasks_max = max(1, int(cfg.get("tasks_max", "1") or "1"))
 
     # 3. Resolve plugin ID (upload if not already known)
     plugin_id = args.plugin_id or cfg.get("plugin_id", "").strip()
@@ -1024,7 +1026,7 @@ def _source_main(argv: Optional[List[str]] = None) -> int:
             else:
                 print(
                     "Warning: Could not discover source cluster topology; "
-                    "falling back to default egress ranges (4100-4107, 4200-4207).",
+                    "falling back to default egress ranges (4100-4103, 4200-4203).",
                     file=sys.stderr,
                 )
 

--- a/sn_confluent/deploy/main.py
+++ b/sn_confluent/deploy/main.py
@@ -16,7 +16,7 @@ import tempfile
 import time
 from typing import List, Optional, Tuple
 
-from sn_confluent.core.pem import check_confluent_cli
+from sn_confluent.core.pem import check_confluent_cli, ensure_authenticated
 from sn_confluent.core.config import load_config as _core_load_config
 
 CONNECTOR_CLASS = "com.servicenow.kafka.connect.hermes.HermesSinkConnector"
@@ -384,7 +384,7 @@ def build_connector_config(
         "hermes.ssl.truststore.password": truststore_password,
         "confluent.custom.connection.endpoints": (
             f"{instance_name}.service-now.com:"
-            + ",".join(str(p) for p in range(4000, 4051))
+            + ",".join(str(p) for p in range(4000, 4008))
         ),
     }
 
@@ -454,12 +454,18 @@ def poll_connector(
 
         try:
             data = json.loads(result.stdout)
-            # Confluent CLI nests status differently across versions; try both shapes
-            state = (
-                data.get("status", {}).get("state")
-                or data.get("connector", {}).get("status", {}).get("state")
-                or "UNKNOWN"
-            ).upper()
+            # CLI v4.x returns {"connector": {"status": "RUNNING", ...}}
+            # Older versions returned {"status": {"state": "RUNNING"}}
+            raw = (
+                data.get("connector", {}).get("status")
+                or data.get("status")
+            )
+            if isinstance(raw, str):
+                state = raw.upper()
+            elif isinstance(raw, dict):
+                state = raw.get("state", "UNKNOWN").upper()
+            else:
+                state = "UNKNOWN"
         except (json.JSONDecodeError, AttributeError):
             state = "UNKNOWN"
 
@@ -614,7 +620,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     cfg = load_config(args.config)
 
     # 2. Check confluent CLI is on PATH and authenticated
-    check_confluent_cli()
+    ensure_authenticated(cfg)
 
     environment_id = cfg["environment_id"]
     cluster_id = cfg["cluster_id"]

--- a/sn_confluent/deploy/main.py
+++ b/sn_confluent/deploy/main.py
@@ -17,8 +17,15 @@ import tempfile
 import time
 from typing import List, Optional, Tuple
 
-from sn_confluent.core.pem import check_confluent_cli, ensure_authenticated
+from sn_confluent.core.pem import (
+    check_confluent_cli,
+    ensure_authenticated,
+    SN_SOURCE_CLUSTERS,
+    SN_BROKERS_PER_CLUSTER,
+)
 from sn_confluent.core.config import load_config as _core_load_config
+from sn_confluent.core.hermes import HermesClient
+from sn_confluent.core.confluent import list_cc_topics
 
 SINK_CONNECTOR_CLASS = "com.servicenow.kafka.connect.hermes.HermesSinkConnector"
 SOURCE_CONNECTOR_CLASS = "com.servicenow.kafka.connect.hermes.HermesSourceConnector"
@@ -225,65 +232,6 @@ def _extract_pem_from_p12(
     return ca_pem, client_cert_pem, client_key_pem
 
 
-def list_cc_topics(environment_id: str, cluster_id: str) -> Optional[List[str]]:
-    """Return sorted CC topic names, or None on failure (caller falls back to manual entry)."""
-    result = subprocess.run(
-        [
-            "confluent", "kafka", "topic", "list",
-            "--cluster", cluster_id,
-            "--environment", environment_id,
-            "--output", "json",
-        ],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        print(f"Warning: Could not list CC topics: {result.stderr.strip()}", file=sys.stderr)
-        return None
-    try:
-        topics = json.loads(result.stdout)
-        return sorted(t["name"] for t in topics)
-    except (json.JSONDecodeError, KeyError):
-        return None
-
-
-def list_hermes_topics(
-    instance_name: str,
-    ca_pem: bytes,
-    client_cert_pem: bytes,
-    client_key_pem: bytes,
-) -> Optional[List[str]]:
-    """Return sorted Hermes topic names via KafkaAdminClient, or None on failure."""
-    try:
-        from kafka.admin import KafkaAdminClient
-    except ImportError:
-        print("Warning: kafka-python not installed; skipping Hermes topic discovery.", file=sys.stderr)
-        return None
-
-    bootstrap = ",".join(f"{instance_name}.service-now.com:{4000 + i}" for i in range(4))
-    admin = None
-    try:
-        admin = KafkaAdminClient(
-            bootstrap_servers=bootstrap,
-            security_protocol="SSL",
-            ssl_cafile_data=ca_pem.decode("utf-8"),
-            ssl_certfile_data=client_cert_pem.decode("utf-8"),
-            ssl_keyfile_data=client_key_pem.decode("utf-8"),
-        )
-        raw = admin.list_topics()
-    except Exception as exc:
-        print(f"Warning: Could not connect to Hermes at {bootstrap}: {exc}", file=sys.stderr)
-        return None
-    finally:
-        if admin is not None:
-            try:
-                admin.close()
-            except Exception:
-                pass
-
-    return sorted(t for t in raw if not t.startswith("__") and not t.startswith("_confluent"))
-
-
 def _resolve_hermes_pem(
     cfg: dict,
     pem_dir: Optional[str],
@@ -420,6 +368,7 @@ def build_source_config(
     truststore_password: str,
     tasks_max: int = 1,
     consumer_group_id: str = "hermes-connect-source",
+    endpoints: Optional[str] = None,
 ) -> dict:
     return {
         "name": connector_name,
@@ -440,12 +389,10 @@ def build_source_config(
         "hermes.ssl.keystore.password": keystore_password,
         "hermes.ssl.truststore.b64": truststore_b64,
         "hermes.ssl.truststore.password": truststore_password,
-        # Two Hermes peer clusters; TODO: verify port ranges and count per cluster
-        "confluent.custom.connection.endpoints": (
+        "confluent.custom.connection.endpoints": endpoints or ",".join(
             f"{instance_name}.service-now.com:"
-            + ",".join(str(p) for p in range(4100, 4108))
-            + f",{instance_name}.service-now.com:"
-            + ",".join(str(p) for p in range(4200, 4208))
+            + ",".join(str(base + i) for i in range(SN_BROKERS_PER_CLUSTER))
+            for base in SN_SOURCE_CLUSTERS
         ),
     }
 
@@ -658,7 +605,7 @@ def _run_sink_wizard(cfg: dict, missing: set) -> dict:
         hermes_pem = _resolve_hermes_pem(cfg, cfg.get("_pem_dir"))
         if hermes_pem and instance_name:
             print(f"Fetching topics from Hermes ({instance_name}.service-now.com)...")
-            hermes_topics = list_hermes_topics(instance_name, *hermes_pem)
+            hermes_topics = HermesClient(instance_name, *hermes_pem).list_topics()
         else:
             hermes_topics = None
 
@@ -730,7 +677,7 @@ def _run_source_wizard(cfg: dict, missing: set) -> dict:
         hermes_pem = _resolve_hermes_pem(cfg, cfg.get("_pem_dir"))
         if hermes_pem and instance_name:
             print(f"Fetching topics from Hermes ({instance_name}.service-now.com)...")
-            hermes_topics = list_hermes_topics(instance_name, *hermes_pem)
+            hermes_topics = HermesClient(instance_name, *hermes_pem).list_topics()
         else:
             hermes_topics = None
 
@@ -1065,6 +1012,22 @@ def _source_main(argv: Optional[List[str]] = None) -> int:
         if not validate_keystores(keystore_b64, keystore_password, truststore_b64, truststore_password):
             sys.exit(1)
 
+    # 7b. Probe actual source cluster broker topology to build precise egress list
+    source_endpoints = None
+    if keystore_b64 and truststore_b64 and instance_name:
+        hermes_pem = _resolve_hermes_pem(cfg, pem_dir)
+        if hermes_pem:
+            print(f"Probing Hermes source cluster topology for {instance_name}...")
+            source_endpoints = HermesClient(instance_name, *hermes_pem).source_egress_endpoints()
+            if source_endpoints:
+                print(f"Discovered egress endpoints: {source_endpoints}")
+            else:
+                print(
+                    "Warning: Could not discover source cluster topology; "
+                    "falling back to default egress ranges (4100-4107, 4200-4207).",
+                    file=sys.stderr,
+                )
+
     # 8. Build connector config
     connector_cfg = build_source_config(
         plugin_id=plugin_id,
@@ -1080,6 +1043,7 @@ def _source_main(argv: Optional[List[str]] = None) -> int:
         truststore_password=truststore_password,
         tasks_max=tasks_max,
         consumer_group_id=consumer_group_id,
+        endpoints=source_endpoints,
     )
 
     # 9. Dry-run: show masked config and exit

--- a/sn_confluent/deploy/tests/test_deploy.py
+++ b/sn_confluent/deploy/tests/test_deploy.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from sn_confluent.deploy import main as dm
+from sn_confluent.core.hermes import HermesClient
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -194,7 +195,7 @@ def test_list_cc_topics_bad_json_returns_none():
 
 
 # ---------------------------------------------------------------------------
-# list_hermes_topics
+# HermesClient.list_topics
 # ---------------------------------------------------------------------------
 
 def _make_pkcs12_b64():
@@ -225,22 +226,22 @@ def _make_pkcs12_b64():
     return base64.b64encode(p12_bytes).decode("ascii")
 
 
-def test_list_hermes_topics_success():
+def test_hermes_client_list_topics_success():
     p12_b64 = _make_pkcs12_b64()
     ca_pem, cert_pem, key_pem = dm._extract_pem_from_p12(p12_b64, "password", p12_b64, "password")
     mock_admin = MagicMock()
     mock_admin.list_topics.return_value = ["snc.inst.sn_streamconnect.t1", "__consumer_offsets"]
     with patch("kafka.admin.KafkaAdminClient", return_value=mock_admin):
-        result = dm.list_hermes_topics("inst", ca_pem, cert_pem, key_pem)
+        result = HermesClient("inst", ca_pem, cert_pem, key_pem).list_topics()
     assert result == ["snc.inst.sn_streamconnect.t1"]
     assert "__consumer_offsets" not in result
 
 
-def test_list_hermes_topics_connection_error_returns_none():
+def test_hermes_client_list_topics_connection_error_returns_none():
     p12_b64 = _make_pkcs12_b64()
     ca_pem, cert_pem, key_pem = dm._extract_pem_from_p12(p12_b64, "password", p12_b64, "password")
     with patch("kafka.admin.KafkaAdminClient", side_effect=Exception("timeout")):
-        result = dm.list_hermes_topics("inst", ca_pem, cert_pem, key_pem)
+        result = HermesClient("inst", ca_pem, cert_pem, key_pem).list_topics()
     assert result is None
 
 

--- a/sn_confluent/deploy/tests/test_deploy.py
+++ b/sn_confluent/deploy/tests/test_deploy.py
@@ -117,7 +117,7 @@ def test_resolve_keystore_empty():
 # ---------------------------------------------------------------------------
 
 def test_build_connector_config_required_keys():
-    cfg = dm.build_connector_config(
+    cfg = dm.build_sink_config(
         plugin_id="ccp-xyz",
         connector_name="hermes-sink",
         topics="topic-a",
@@ -130,7 +130,7 @@ def test_build_connector_config_required_keys():
         truststore_b64="TS==",
         truststore_password="tspw",
     )
-    assert cfg["connector.class"] == dm.CONNECTOR_CLASS
+    assert cfg["connector.class"] == dm.SINK_CONNECTOR_CLASS
     assert cfg["confluent.custom.plugin.id"] == "ccp-xyz"
     assert cfg["confluent.connector.type"] == "CUSTOM"
     assert cfg["kafka.auth.mode"] == "KAFKA_API_KEY"
@@ -141,7 +141,7 @@ def test_build_connector_config_required_keys():
 
 
 def test_build_connector_config_tasks_max():
-    cfg = dm.build_connector_config(
+    cfg = dm.build_sink_config(
         "ccp-1", "n", "t", "k", "s", "i", "h", "ks", "kp", "ts", "tp", tasks_max=4
     )
     assert cfg["tasks.max"] == "4"
@@ -307,26 +307,26 @@ def _make_proc(returncode=0, stdout="", stderr=""):
 def test_upload_plugin_success():
     payload = json.dumps({"id": "ccp-newplugin", "name": "test-plugin"})
     with patch("subprocess.run", return_value=_make_proc(stdout=payload)):
-        pid = dm.upload_plugin("/fake/connector.zip", "test-plugin", "aws")
+        pid = dm.upload_plugin("/fake/connector.zip", "test-plugin", "aws", "sink", dm.SINK_CONNECTOR_CLASS)
     assert pid == "ccp-newplugin"
 
 
 def test_upload_plugin_failure_exits():
     with patch("subprocess.run", return_value=_make_proc(returncode=1, stderr="auth error")):
         with pytest.raises(SystemExit):
-            dm.upload_plugin("/fake/connector.zip", "test-plugin", "aws")
+            dm.upload_plugin("/fake/connector.zip", "test-plugin", "aws", "sink", dm.SINK_CONNECTOR_CLASS)
 
 
 def test_upload_plugin_bad_json_exits():
     with patch("subprocess.run", return_value=_make_proc(stdout="not-json")):
         with pytest.raises(SystemExit):
-            dm.upload_plugin("/fake/connector.zip", "test-plugin", "aws")
+            dm.upload_plugin("/fake/connector.zip", "test-plugin", "aws", "sink", dm.SINK_CONNECTOR_CLASS)
 
 
 def test_upload_plugin_missing_id_exits():
     with patch("subprocess.run", return_value=_make_proc(stdout=json.dumps({"name": "p"}))):
         with pytest.raises(SystemExit):
-            dm.upload_plugin("/fake/connector.zip", "test-plugin", "aws")
+            dm.upload_plugin("/fake/connector.zip", "test-plugin", "aws", "sink", dm.SINK_CONNECTOR_CLASS)
 
 
 # ---------------------------------------------------------------------------
@@ -386,10 +386,10 @@ def test_poll_connector_timeout_exits():
 
 def test_main_dry_run(tmp, capsys):
     conf = _write_conf(tmp)
-    with patch("sn_confluent.deploy.main.check_confluent_cli"):
+    with patch("sn_confluent.deploy.main.ensure_authenticated"):
         with patch("sn_confluent.deploy.main._glob.glob", return_value=[]):
             with patch("sn_confluent.deploy.main.validate_keystores", return_value=True):
-                rc = dm.main(["--config", conf, "--dry-run", "--no-wizard"])
+                rc = dm.main(["sink", "--config", conf, "--dry-run", "--no-wizard"])
     assert rc == 0
     out = capsys.readouterr().out
     assert "dry-run" in out
@@ -400,18 +400,18 @@ def test_main_dry_run(tmp, capsys):
 
 def test_main_missing_plugin_no_wizard_exits(tmp):
     conf = _write_conf(tmp, MINIMAL_CONF.replace("plugin_id = ccp-abc123", "plugin_id ="))
-    with patch("sn_confluent.deploy.main.check_confluent_cli"):
+    with patch("sn_confluent.deploy.main.ensure_authenticated"):
         with patch("sn_confluent.deploy.main._glob.glob", return_value=[]):
             with pytest.raises(SystemExit):
-                dm.main(["--config", conf, "--no-wizard"])
+                dm.main(["sink", "--config", conf, "--no-wizard"])
 
 
 def test_main_missing_topics_no_wizard_exits(tmp):
     conf_text = MINIMAL_CONF.replace("topics = my-topic", "topics =")
     conf = _write_conf(tmp, conf_text)
-    with patch("sn_confluent.deploy.main.check_confluent_cli"):
+    with patch("sn_confluent.deploy.main.ensure_authenticated"):
         with pytest.raises(SystemExit):
-            dm.main(["--config", conf, "--no-wizard"])
+            dm.main(["sink", "--config", conf, "--no-wizard"])
 
 
 # ---------------------------------------------------------------------------

--- a/sn_confluent/extract/README.md
+++ b/sn_confluent/extract/README.md
@@ -11,10 +11,10 @@ pip install -r requirements.txt
 ## Usage
 
 ```bash
-python extract_pem.py \
-  --keystore path/to/keystore \
-  --truststore path/to/truststore \
-  --out-dir /tmp/pems
+sn-confluent extract \
+    --keystore path/to/keystore \
+    --truststore path/to/truststore \
+    --out-dir /tmp/pems
 ```
 
 Prompts once for the keystore password, then writes:

--- a/sn_confluent/link/README.md
+++ b/sn_confluent/link/README.md
@@ -44,7 +44,7 @@ instance_name       = snc.yourinstance
 ## Usage
 
 ```bash
-python create_link.py --pem-dir /path/to/pems
+sn-confluent link --pem-dir /path/to/pems
 ```
 
 ## Options
@@ -69,7 +69,7 @@ KEY_PASSWORD=yourpassword sn-confluent link
 Use `--copy-config` to copy the SSL properties block to your clipboard, then paste into **Environments → Cluster links → Create cluster link → Additional configurations**.
 
 ```bash
-python create_link.py --pem-dir /path/to/pems --copy-config
+sn-confluent link --pem-dir /path/to/pems --copy-config
 ```
 
 ## Tests

--- a/sn_confluent/mirror/README.md
+++ b/sn_confluent/mirror/README.md
@@ -19,7 +19,7 @@ pip install -e .[dev]
 ## Usage
 
 ```bash
-python -m sn_confluent.mirror.main [--config PATH] [--pem-dir PATH] [--filter PREFIX] [--all] [--dry-run]
+sn-confluent mirror [--config PATH] [--pem-dir PATH] [--filter PREFIX] [--all] [--dry-run]
                                    [--include-prefixes PREFIX ...] [--exclude-prefixes PREFIX ...]
                                    [--include-topics TOPIC ...] [--exclude-topics TOPIC ...]
 ```
@@ -27,7 +27,7 @@ python -m sn_confluent.mirror.main [--config PATH] [--pem-dir PATH] [--filter PR
 Default run — shows a checkbox list of topics filtered by `instance_name` from `link.conf`:
 
 ```bash
-python -m sn_confluent.mirror.main --pem-dir /tmp/pems
+sn-confluent mirror --pem-dir /tmp/pems
 ```
 
 ## Options

--- a/sn_confluent/replicate/README.md
+++ b/sn_confluent/replicate/README.md
@@ -72,23 +72,23 @@ source_clusters     = 4100,4200       # one connector per cluster
 
 ```bash
 # Interactive wizard (cc-to-sn, default)
-python setup_replicator.py
+sn-confluent replicate
 
 # Non-interactive with all topics
-python setup_replicator.py --all --no-wizard
+sn-confluent replicate --all --no-wizard
 
 # Specific topics
-python setup_replicator.py --topics hermes_incidents,hermes_changes
+sn-confluent replicate --topics hermes_incidents,hermes_changes
 
 # Opposite direction
-python setup_replicator.py --direction sn-to-cc
+sn-confluent replicate --direction sn-to-cc
 
 # Dry-run (prints config, no create)
-python setup_replicator.py --dry-run
-python setup_replicator.py --all --no-wizard --dry-run
+sn-confluent replicate --dry-run
+sn-confluent replicate --all --no-wizard --dry-run
 
 # Override connect worker URL
-python setup_replicator.py --connect-url http://my-worker:8083
+sn-confluent replicate --connect-url http://my-worker:8083
 ```
 
 ## Options
@@ -122,7 +122,7 @@ sn-confluent replicate
 |---|---|
 | Connector status is `FAILED` | Check Connect worker logs. For cc-to-sn, verify `connector.client.config.override.policy=All` in worker properties. |
 | "Not authenticated" or 401 from Confluent CLI | Run `confluent login` and retry. |
-| PEM files not found | Run `python ../extract-pem/extract_pem.py` first. See [`extract-pem`](../extract-pem/). |
+| PEM files not found | Run `sn-confluent extract` first. See [`extract-pem`](../extract-pem/). |
 | Connector writes to wrong cluster (cc-to-sn) | Override policy is not set. `producer.override.*` settings are silently ignored without it. |
 | Connection refused on connect URL | Verify the Connect worker is running and the URL/port is correct. |
 

--- a/sn_confluent/replicate/main.py
+++ b/sn_confluent/replicate/main.py
@@ -407,6 +407,7 @@ def main(argv: Optional[List[str]] = None) -> int:
                 print("Fetching topics from SN Hermes...")
                 client = HermesClient(
                     source_host, ca_pem, client_cert, client_key, key_password,
+                    brokers_per_cluster=brokers_per_cluster,
                 )
                 available = client.list_topics(base_port=source_clusters[0])
                 if available is None:

--- a/sn_confluent/replicate/main.py
+++ b/sn_confluent/replicate/main.py
@@ -20,6 +20,8 @@ from sn_confluent.core.pem import (
     check_confluent_cli, load_pem_files,
 )
 from sn_confluent.core.config import load_config as _core_load_config
+from sn_confluent.core.confluent import list_cc_topics as _list_cc_topics
+from sn_confluent.core.hermes import HermesClient
 
 SN_INBOUND_PORT = 4000
 
@@ -90,70 +92,12 @@ def get_cc_bootstrap(environment_id: str, cluster_id: str) -> str:
 
 
 def list_cc_topics(environment_id: str, cluster_id: str) -> list[str]:
-    """List topics on the CC cluster via confluent CLI."""
-    result = subprocess.run(
-        [
-            "confluent", "kafka", "topic", "list",
-            "--cluster", cluster_id,
-            "--environment", environment_id,
-            "--output", "json",
-        ],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        print(f"Error: Failed to list CC topics: {result.stderr.strip()}", file=sys.stderr)
+    """List CC topics, exiting on failure."""
+    result = _list_cc_topics(environment_id, cluster_id)
+    if result is None:
+        print("Error: Failed to list CC topics.", file=sys.stderr)
         sys.exit(1)
-    try:
-        topics = json.loads(result.stdout)
-        return sorted(t["name"] for t in topics)
-    except (json.JSONDecodeError, KeyError) as exc:
-        print(f"Error: Unexpected topic list output: {exc}", file=sys.stderr)
-        sys.exit(1)
-
-
-def list_sn_topics(
-    source_host: str,
-    source_clusters: list[int],
-    brokers_per_cluster: int,
-    ca_pem_bytes: bytes,
-    client_cert_bytes: bytes,
-    client_key_bytes: bytes,
-    key_password: Optional[str],
-) -> list[str]:
-    """List topics on SN Hermes via kafka-python AdminClient."""
-    try:
-        from kafka.admin import KafkaAdminClient
-    except ImportError:
-        print(
-            "Error: kafka-python is required for SN topic listing.\n"
-            "Install it: pip install kafka-python",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-
-    base_port = source_clusters[0]
-    bootstrap = ",".join(
-        f"{source_host}:{base_port + i}" for i in range(brokers_per_cluster)
-    )
-    ssl_context_kwargs = {
-        "bootstrap_servers": bootstrap,
-        "security_protocol": "SSL",
-        "ssl_cafile_data": ca_pem_bytes.decode("utf-8"),
-        "ssl_certfile_data": client_cert_bytes.decode("utf-8"),
-        "ssl_keyfile_data": client_key_bytes.decode("utf-8"),
-    }
-    if key_password:
-        ssl_context_kwargs["ssl_password"] = key_password
-    try:
-        admin = KafkaAdminClient(**ssl_context_kwargs)
-        raw = admin.list_topics()
-        admin.close()
-    except Exception as exc:
-        print(f"Error: Failed to list SN topics: {exc}", file=sys.stderr)
-        sys.exit(1)
-
-    return sorted(t for t in raw if not t.startswith("__") and not t.startswith("_confluent"))
+    return result
 
 
 def build_topic_regex(topics: Optional[List[str]], use_all: bool) -> str:
@@ -461,10 +405,13 @@ def main(argv: Optional[List[str]] = None) -> int:
                 available = list_cc_topics(cfg["environment_id"], cfg["cluster_id"])
             else:
                 print("Fetching topics from SN Hermes...")
-                available = list_sn_topics(
-                    source_host, source_clusters, brokers_per_cluster,
-                    ca_pem, client_cert, client_key, key_password,
+                client = HermesClient(
+                    source_host, ca_pem, client_cert, client_key, key_password,
                 )
+                available = client.list_topics(base_port=source_clusters[0])
+                if available is None:
+                    print("Error: Failed to list SN topics.", file=sys.stderr)
+                    sys.exit(1)
 
             if not available:
                 print("No topics found on source cluster.")

--- a/sn_confluent/replicate/tests/test_replicate.py
+++ b/sn_confluent/replicate/tests/test_replicate.py
@@ -222,7 +222,7 @@ def test_source_clusters_default(tmp):
 # =========================================================================
 
 
-@patch("sn_confluent.replicate.main.subprocess.run")
+@patch("sn_confluent.core.confluent.subprocess.run")
 def test_list_cc_topics(mock_run):
     mock_run.return_value = MagicMock(
         returncode=0,
@@ -237,27 +237,25 @@ def test_list_cc_topics(mock_run):
     mock_run.assert_called_once()
 
 
-@patch("sn_confluent.replicate.main.subprocess.run")
+@patch("sn_confluent.core.confluent.subprocess.run")
 def test_list_cc_topics_failure_exits(mock_run):
     mock_run.return_value = MagicMock(returncode=1, stderr="oops")
     with pytest.raises(SystemExit):
         sr.list_cc_topics("env-1", "lkc-1")
 
 
-@patch("sn_confluent.replicate.main.KafkaAdminClient", create=True)
-def test_list_sn_topics(_unused):
-    """Mock KafkaAdminClient at the import location inside list_sn_topics."""
+def test_hermes_client_list_topics_from_source_cluster():
+    """HermesClient.list_topics with a source-cluster base_port."""
     mock_admin_instance = MagicMock()
     mock_admin_instance.list_topics.return_value = [
         "topicB", "__consumer_offsets", "topicA", "_confluent-metrics",
     ]
-    mock_admin_cls = MagicMock(return_value=mock_admin_instance)
-
-    with patch.dict("sys.modules", {"kafka": MagicMock(), "kafka.admin": MagicMock(KafkaAdminClient=mock_admin_cls)}):
-        result = sr.list_sn_topics(
-            "host", [4100], 4,
-            FAKE_CA, FAKE_CERT, FAKE_KEY, None,
-        )
+    with patch.dict("sys.modules", {
+        "kafka": MagicMock(),
+        "kafka.admin": MagicMock(KafkaAdminClient=MagicMock(return_value=mock_admin_instance)),
+    }):
+        from sn_confluent.core.hermes import HermesClient
+        result = HermesClient("host", FAKE_CA, FAKE_CERT, FAKE_KEY).list_topics(base_port=4100)
     assert result == ["topicA", "topicB"]
 
 


### PR DESCRIPTION
## Summary
- Fix stale `python <script>.py` invocations in extract, link, replicate, and mirror READMEs — those scripts no longer exist; the unified `sn-confluent` CLI is the correct entry point
- Add missing `worker`, `deploy sink/source`, and `api-key` subcommands to the root README table and workflow section
- Update CONTRIBUTING.md repo layout tree to include `deploy/`, `worker/`, and `api_key/` directories
- Create `sn_confluent/deploy/README.md` — the only subcommand with code but no README

## Test plan
- [ ] `grep -r "extract_pem.py\|create_link.py\|setup_replicator.py" sn_confluent/` returns 0 matches in docs
- [ ] All 8 subcommands in `cli.py` `SUBCOMMAND_HELP` appear in the root README table
- [ ] `sn_confluent/deploy/README.md` exists and covers sink/source flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)