### PR TITLE
fix: correct confluent.custom.connection.endpoints format

### DIFF
--- a/sn_confluent/deploy/main.py
+++ b/sn_confluent/deploy/main.py
@@ -347,9 +347,10 @@ def build_sink_config(
         "hermes.ssl.keystore.password": keystore_password,
         "hermes.ssl.truststore.b64": truststore_b64,
         "hermes.ssl.truststore.password": truststore_password,
-        "confluent.custom.connection.endpoints": ",".join(
-            f"{instance_name if '.' in instance_name else instance_name + '.service-now.com'}:{p}"
-            for p in range(4000, 4008)
+        "confluent.custom.connection.endpoints": (
+            (instance_name if "." in instance_name else instance_name + ".service-now.com")
+            + ":"
+            + ",".join(str(p) for p in range(4000, 4008))
         ),
     }
 
@@ -389,10 +390,14 @@ def build_source_config(
         "hermes.ssl.keystore.password": keystore_password,
         "hermes.ssl.truststore.b64": truststore_b64,
         "hermes.ssl.truststore.password": truststore_password,
-        "confluent.custom.connection.endpoints": endpoints or ",".join(
-            f"{instance_name if '.' in instance_name else instance_name + '.service-now.com'}:{base + i}"
-            for base in SN_SOURCE_CLUSTERS
-            for i in range(SN_BROKERS_PER_CLUSTER)
+        "confluent.custom.connection.endpoints": endpoints or (
+            (instance_name if "." in instance_name else instance_name + ".service-now.com")
+            + ":"
+            + ",".join(
+                str(base + i)
+                for base in SN_SOURCE_CLUSTERS
+                for i in range(SN_BROKERS_PER_CLUSTER)
+            )
         ),
     }
 

--- a/sn_confluent/deploy/tests/test_deploy.py
+++ b/sn_confluent/deploy/tests/test_deploy.py
@@ -148,6 +148,45 @@ def test_build_connector_config_tasks_max():
     assert cfg["tasks.max"] == "4"
 
 
+def test_build_sink_config_endpoints_format():
+    cfg = dm.build_sink_config(
+        "ccp-1", "n", "t", "k", "s", "myinstance", "h", "ks", "kp", "ts", "tp"
+    )
+    assert cfg["confluent.custom.connection.endpoints"] == (
+        "myinstance.service-now.com:4000,4001,4002,4003,4004,4005,4006,4007"
+    )
+
+
+def test_build_sink_config_endpoints_fqdn():
+    cfg = dm.build_sink_config(
+        "ccp-1", "n", "t", "k", "s", "myinstance.service-now.com", "h", "ks", "kp", "ts", "tp"
+    )
+    ep = cfg["confluent.custom.connection.endpoints"]
+    assert ep.startswith("myinstance.service-now.com:")
+    assert "service-now.com.service-now.com" not in ep
+
+
+def test_build_source_config_endpoints_format():
+    from sn_confluent.core.pem import SN_SOURCE_CLUSTERS, SN_BROKERS_PER_CLUSTER
+    cfg = dm.build_source_config(
+        "ccp-1", "n", "dest", "k", "s", "myinstance", "src", "ks", "kp", "ts", "tp"
+    )
+    ep = cfg["confluent.custom.connection.endpoints"]
+    assert ep.startswith("myinstance.service-now.com:")
+    expected_ports = ",".join(
+        str(base + i) for base in SN_SOURCE_CLUSTERS for i in range(SN_BROKERS_PER_CLUSTER)
+    )
+    assert ep == "myinstance.service-now.com:" + expected_ports
+
+
+def test_build_source_config_endpoints_override():
+    cfg = dm.build_source_config(
+        "ccp-1", "n", "dest", "k", "s", "myinstance", "src", "ks", "kp", "ts", "tp",
+        endpoints="custom.host:9000,9001",
+    )
+    assert cfg["confluent.custom.connection.endpoints"] == "custom.host:9000,9001"
+
+
 # ---------------------------------------------------------------------------
 # validate_keystores
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fixes #45
- `build_sink_config` now emits `host:4000,4001,...,4007` instead of `host:4000,host:4001,...`
- `build_source_config` now emits `host:4100,4101,...,4200,...` (all ports from both source clusters after a single host prefix)
- Explicit `endpoints` override in `build_source_config` still passes through unchanged

## Test plan

- [ ] `python -m pytest sn_confluent/deploy/tests/test_deploy.py -v` — all 45 tests pass (4 new endpoint-format tests added)
- [ ] `test_build_sink_config_endpoints_format` — verifies `myinstance.service-now.com:4000,...,4007`
- [ ] `test_build_sink_config_endpoints_fqdn` — verifies no double `.service-now.com` suffix
- [ ] `test_build_source_config_endpoints_format` — verifies combined port list from both source clusters
- [ ] `test_build_source_config_endpoints_override` — verifies explicit `endpoints` arg passes through as-is

🤖 Generated with [Claude Code](https://claude.com/claude-code)