### PR TITLE
chore: bump version to 0.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sn-confluent"
-version = "0.2.0"
+version = "0.2.1"
 description = "CLI tools for integrating ServiceNow's Kafka infrastructure with Confluent Cloud."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Version bump for patch release v0.2.1.

Includes the fix from #46: `confluent.custom.connection.endpoints` now uses the correct `host:port1,port2,...` format accepted by Confluent Cloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)