### PR TITLE
fix: harden three security and reliability bugs (#17, #19, #20)

### DIFF
--- a/sn_confluent/core/config.py
+++ b/sn_confluent/core/config.py
@@ -67,13 +67,29 @@ def expand_link_config(cfg: dict) -> dict:
     `add_per_cluster_link_names()`.
     """
     clusters_raw = cfg.get("source_clusters", "")
-    cfg["source_clusters"] = (
-        [int(x.strip()) for x in clusters_raw.split(",") if x.strip()]
-        if clusters_raw
-        else list(SN_SOURCE_CLUSTERS)
-    )
+    if clusters_raw:
+        try:
+            cfg["source_clusters"] = [int(x.strip()) for x in clusters_raw.split(",") if x.strip()]
+        except ValueError:
+            print(
+                f"Error: source_clusters in link.conf must be a comma-separated list of integers: {clusters_raw!r}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    else:
+        cfg["source_clusters"] = list(SN_SOURCE_CLUSTERS)
     bpc_raw = cfg.get("brokers_per_cluster", "")
-    cfg["brokers_per_cluster"] = int(bpc_raw) if bpc_raw else SN_BROKERS_PER_CLUSTER
+    if bpc_raw:
+        try:
+            cfg["brokers_per_cluster"] = int(bpc_raw)
+        except ValueError:
+            print(
+                f"Error: brokers_per_cluster in link.conf must be an integer: {bpc_raw!r}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    else:
+        cfg["brokers_per_cluster"] = SN_BROKERS_PER_CLUSTER
     return cfg
 
 

--- a/sn_confluent/extract/main.py
+++ b/sn_confluent/extract/main.py
@@ -118,9 +118,18 @@ def _write(path: str, data: bytes) -> None:
 
 
 def _write_private(path: str, data: bytes) -> None:
-    """Write data to path with 0o600 permissions from creation — no world-readable window."""
-    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-    with os.fdopen(fd, "wb") as fh:
+    """Write data to path with 0o600 permissions from creation (Unix: no world-readable window).
+
+    On Windows POSIX mode bits are ignored; set_key_permissions() will emit a warning.
+    """
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0)
+    fd = os.open(path, flags, 0o600)
+    try:
+        fh = os.fdopen(fd, "wb")
+    except Exception:
+        os.close(fd)
+        raise
+    with fh:
         fh.write(data)
 
 

--- a/sn_confluent/extract/main.py
+++ b/sn_confluent/extract/main.py
@@ -117,6 +117,13 @@ def _write(path: str, data: bytes) -> None:
         fh.write(data)
 
 
+def _write_private(path: str, data: bytes) -> None:
+    """Write data to path with 0o600 permissions from creation — no world-readable window."""
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "wb") as fh:
+        fh.write(data)
+
+
 def main(argv: Optional[List[str]] = None) -> int:
     parser = argparse.ArgumentParser(
         description="Extract CA and client PEM files from PKCS12 keystores for mTLS."
@@ -148,7 +155,7 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     _write(ca_path, ca_pem)
     _write(cert_path, client_cert_pem)
-    _write(key_path, client_key_pem)
+    _write_private(key_path, client_key_pem)
     set_key_permissions(key_path)
 
     print(f"Written: {ca_path}")

--- a/sn_confluent/link/tests/test_link.py
+++ b/sn_confluent/link/tests/test_link.py
@@ -129,6 +129,40 @@ def test_load_config_reads_custom_brokers_per_cluster(tmp_path):
     assert cfg["brokers_per_cluster"] == 2
 
 
+def test_load_config_exits_on_non_integer_source_clusters(tmp_path, capsys):
+    from sn_confluent.link.main import load_config
+    cfg_text = textwrap.dedent("""\
+        [confluent]
+        environment_id   = env-abc123
+        cluster_id       = lkc-abc123
+        link_name        = test-link
+        source_bootstrap = broker.example.com:9093
+        source_clusters  = 4100, abc
+    """)
+    path = write_config(tmp_path, cfg_text)
+    with pytest.raises(SystemExit) as exc_info:
+        load_config(path)
+    assert exc_info.value.code == 1
+    assert "source_clusters" in capsys.readouterr().err
+
+
+def test_load_config_exits_on_non_integer_brokers_per_cluster(tmp_path, capsys):
+    from sn_confluent.link.main import load_config
+    cfg_text = textwrap.dedent("""\
+        [confluent]
+        environment_id      = env-abc123
+        cluster_id          = lkc-abc123
+        link_name           = test-link
+        source_bootstrap    = broker.example.com:9093
+        brokers_per_cluster = two
+    """)
+    path = write_config(tmp_path, cfg_text)
+    with pytest.raises(SystemExit) as exc_info:
+        load_config(path)
+    assert exc_info.value.code == 1
+    assert "brokers_per_cluster" in capsys.readouterr().err
+
+
 def test_load_config_exits_if_neither_source_key(tmp_path):
     from sn_confluent.link.main import load_config
     bad = textwrap.dedent("""\

--- a/sn_confluent/mirror/main.py
+++ b/sn_confluent/mirror/main.py
@@ -100,11 +100,11 @@ def get_mirrored_source_topics(cfg: dict) -> set:
         if result.returncode != 0:
             link = cfg.get(f"link_name_{port}", str(port))
             print(
-                f"Error: 'confluent kafka mirror list' failed for link {link}: "
-                f"{result.stderr.strip()}",
+                f"Warning: could not list existing mirrors for link {link} "
+                f"({result.stderr.strip()}); [mirrored] labels will be absent.",
                 file=sys.stderr,
             )
-            sys.exit(1)
+            continue
         try:
             mirrors = json.loads(result.stdout)
             for m in mirrors:

--- a/sn_confluent/mirror/main.py
+++ b/sn_confluent/mirror/main.py
@@ -98,7 +98,13 @@ def get_mirrored_source_topics(cfg: dict) -> set:
             text=True,
         )
         if result.returncode != 0:
-            continue
+            link = cfg.get(f"link_name_{port}", str(port))
+            print(
+                f"Error: 'confluent kafka mirror list' failed for link {link}: "
+                f"{result.stderr.strip()}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
         try:
             mirrors = json.loads(result.stdout)
             for m in mirrors:

--- a/sn_confluent/mirror/tests/test_mirror.py
+++ b/sn_confluent/mirror/tests/test_mirror.py
@@ -207,7 +207,7 @@ def test_get_mirrored_source_topics_strips_prefix():
     assert result == {"foo", "bar", "baz"}
 
 
-def test_get_mirrored_source_topics_exits_on_cli_failure(capsys):
+def test_get_mirrored_source_topics_warns_and_returns_empty_on_cli_failure(capsys):
     from sn_confluent.mirror.main import get_mirrored_source_topics
     link_cfg = {
         "link_name_4100": "servicenow-link-4100",
@@ -217,10 +217,11 @@ def test_get_mirrored_source_topics_exits_on_cli_failure(capsys):
     }
     mock_result = MagicMock(returncode=1, stdout="", stderr="Unauthorized")
     with patch("sn_confluent.mirror.main.subprocess.run", return_value=mock_result):
-        with pytest.raises(SystemExit) as exc_info:
-            get_mirrored_source_topics(link_cfg)
-    assert exc_info.value.code == 1
-    assert "confluent kafka mirror list" in capsys.readouterr().err
+        result = get_mirrored_source_topics(link_cfg)
+    assert result == set()
+    err = capsys.readouterr().err
+    assert "Warning" in err
+    assert "servicenow-link-4100" in err
 
 
 # ---------------------------------------------------------------------------

--- a/sn_confluent/mirror/tests/test_mirror.py
+++ b/sn_confluent/mirror/tests/test_mirror.py
@@ -207,7 +207,7 @@ def test_get_mirrored_source_topics_strips_prefix():
     assert result == {"foo", "bar", "baz"}
 
 
-def test_get_mirrored_source_topics_returns_empty_on_cli_failure():
+def test_get_mirrored_source_topics_exits_on_cli_failure(capsys):
     from sn_confluent.mirror.main import get_mirrored_source_topics
     link_cfg = {
         "link_name_4100": "servicenow-link-4100",
@@ -215,9 +215,12 @@ def test_get_mirrored_source_topics_returns_empty_on_cli_failure():
         "environment_id": "env-abc123",
         "cluster_id": "lkc-abc123",
     }
-    with patch("sn_confluent.mirror.main.subprocess.run", return_value=MagicMock(returncode=1, stdout="")):
-        result = get_mirrored_source_topics(link_cfg)
-    assert result == set()
+    mock_result = MagicMock(returncode=1, stdout="", stderr="Unauthorized")
+    with patch("sn_confluent.mirror.main.subprocess.run", return_value=mock_result):
+        with pytest.raises(SystemExit) as exc_info:
+            get_mirrored_source_topics(link_cfg)
+    assert exc_info.value.code == 1
+    assert "confluent kafka mirror list" in capsys.readouterr().err
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **#20 (security)** \`extract\`: write \`client-key.pem\` with \`0o600\` permissions from creation using \`os.open()\` with \`O_NOFOLLOW\`, eliminating the world-readable window and preventing symlink-follow attacks; fd leak guard added if \`os.fdopen\` raises
- **#17 (reliability)** \`mirror\`: emit a named warning when \`confluent kafka mirror list\` fails and continue — the \`[mirrored]\` label annotation is informational; hard-aborting here was disproportionate relative to \`create_mirror_topics\` which collects failures softly
- **#19 (UX)** \`config\`: wrap both \`int()\` coercions in \`expand_link_config()\` with \`try/except ValueError\` so a malformed \`source_clusters\` or \`brokers_per_cluster\` in \`link.conf\` produces a clear error message instead of a raw Python traceback

## Test plan

- [x] 158 tests pass, 1 skipped (net +2 from baseline)
- [x] Added \`test_load_config_exits_on_non_integer_source_clusters\` and \`test_load_config_exits_on_non_integer_brokers_per_cluster\` to cover the new error paths in \`expand_link_config\`
- [x] Updated mirror CLI-failure test to assert warn-and-continue behavior (not hard exit)
- [x] \`#18\` (KafkaConsumer timeout) was already fixed in the codebase — closed separately with a comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)