### PR TITLE
chore: bump version to 1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sn-confluent"
-version = "0.2.1"
+version = "1.0.0"
 description = "CLI tools for integrating ServiceNow's Kafka infrastructure with Confluent Cloud."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Bumps `pyproject.toml` version from `0.2.1` → `1.0.0` for the v1.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)