### PR TITLE
chore: add release workflow to auto-build and upload artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-upload:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Build distribution
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - name: Upload artifacts to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ github.ref_name }}" dist/* --repo "${{ github.repository }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,20 @@ jobs:
           python-version: "3.11"
           cache: "pip"
 
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest sn_confluent/ -v
+
       - name: Build distribution
         run: |
-          python -m pip install --upgrade pip build
+          pip install build
           python -m build
 
       - name: Upload artifacts to release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${{ github.ref_name }}" dist/* --repo "${{ github.repository }}"
+        run: gh release upload "${{ github.ref_name }}" dist/* --repo "${{ github.repository }}" --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,15 +23,13 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          pip install -e ".[dev]" build
 
       - name: Run tests
         run: pytest sn_confluent/ -v
 
       - name: Build distribution
-        run: |
-          pip install build
-          python -m build
+        run: python -m build
 
       - name: Upload artifacts to release
         env:


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release.yml` that triggers on `release: published`
- Installs `build`, runs `python -m build`, and uploads `dist/*` (sdist + wheel) to the release via `gh release upload`
- Uses `contents: write` permission and `GITHUB_TOKEN` — no secrets needed

## Test plan

- [ ] Merge this PR
- [ ] Create a new release (e.g. v1.0.1) — verify the workflow runs and attaches `.tar.gz` and `.whl` to the release assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)