### PR TITLE
chore: gitignore graphify output and secret-bearing working files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,12 @@ docs/superpowers/
 
 #Claude
 .claude/
+
+# graphify generated knowledge graph (derived artifact; may embed config/secret fragments)
+graphify-out/
+
+# Connector configs and traces — may contain inline keystores/passwords
+connector-*.json
+*-support-ticket.md
+trace_out.txt
+hermes-connector-bundled.zip


### PR DESCRIPTION
## Summary
- `graphify-out/` is a derived artifact; its `graph.json`/report embed verbatim fragments (keystore b64, passwords) pulled from untracked config files, so committing it would defeat the secret-tuned `.gitignore`.
- Also ignore `connector-*.json`, `*-support-ticket.md`, `trace_out.txt`, and `hermes-connector-bundled.zip` — untracked working files that carry the same inline credentials and were not matched by any existing rule (a `git add -A` would have committed them).
- Aligns with CONTRIBUTING.md "Secrets and credentials": never commit keystores, passwords, or live cluster IDs.

## Test plan
- [x] `git check-ignore` confirms all six target paths resolve as IGNORED
- [ ] Confirm no currently-tracked file is newly ignored (.gitignore-only change; no tracked files removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)